### PR TITLE
feat: add Claude Code /accrue skill and docs

### DIFF
--- a/.claude/skills/accrue/SKILL.md
+++ b/.claude/skills/accrue/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: accrue
+description: "Build data enrichment pipelines with Accrue. Use when the user wants to enrich a CSV or dataset with LLM-generated fields — company research, lead qualification, classification, extraction, tagging. Guides field design, model selection, prompt crafting, and pipeline configuration. Trigger on: enrich, qualify leads, research companies, classify data, enrich CSV, build pipeline, data enrichment, ICP scoring, account qualification."
+---
+
+# Accrue Pipeline Builder
+
+Guide users through designing and running enrichment pipelines. Follow these 6 phases in order. Be opinionated — recommend best practices, don't just ask what the user wants.
+
+## Phase 0: Environment Setup (run before anything else)
+
+Accrue must be installed before any pipeline can run. This phase ensures the environment is ready — especially important in ephemeral environments like Cowork VMs where nothing is pre-installed.
+
+1. **Check if Accrue is installed:**
+   ```bash
+   python -c "import accrue; print(accrue.__version__)" 2>&1
+   ```
+2. **If not installed, install it.** Pick the right extra based on which provider the user wants:
+   ```bash
+   pip install accrue                # OpenAI only (default)
+   pip install "accrue[anthropic]"   # + Anthropic (Claude models)
+   pip install "accrue[google]"      # + Google (Gemini models)
+   pip install "accrue[all]"         # All providers
+   ```
+   If `pip` is unavailable, try `uv pip install` instead. Ensure Python 3.10+ is being used.
+3. **Check for API keys.** Accrue auto-loads `.env` via python-dotenv. Verify the relevant key exists:
+   - OpenAI → `OPENAI_API_KEY`
+   - Anthropic → `ANTHROPIC_API_KEY`
+   - Google → `GOOGLE_API_KEY`
+
+   If no `.env` file exists and no key is set in the environment, **stop and ask the user** before proceeding. Do not attempt to run a pipeline without a valid API key.
+
+## Phase 1: Understand the Enrichment
+
+1. **Read the input data.** Find and read any CSV/data file. Check columns, row count, sample 3-5 rows.
+2. **Ask the goal.** "What are you trying to accomplish with this enrichment?" and "Who consumes this data?"
+3. **Match to an archetype** (propose if the user is vague):
+   - **Account qualification** — ICP fit, industry, employee count, signals
+   - **Lead research** — role relevance, seniority, personalization hooks
+   - **Company intelligence** — tech stack, funding, news, competitors
+   - **Content extraction** — structured data from unstructured text
+   - **Classification/tagging** — categorize existing data into buckets
+4. **Check data quality.** Flag: duplicates, missing key columns, dirty values. Suggest cleanup before enriching.
+5. **Flag cost early.** Row count drives cost. >1000 rows: mention batch mode. >5000 rows: discuss workers and checkpointing.
+
+If the user is vague about fields, **don't wait** — propose a field set based on the archetype with rationale. It's easier to edit a proposal than start from scratch.
+
+## Phase 2: Design Fields
+
+This is the most important phase. Good field specs = good enrichment. Bad fields = garbage in, garbage out.
+
+For each field, define using Accrue's 7-key spec. Read [api.md](references/api.md) for the full FieldSpec schema.
+
+### Field Design Principles
+
+- **Enums over free text.** Constrained outputs are more useful downstream. Always include an "Other" or "Unknown" escape hatch.
+- **Specific prompts.** "Estimated employee count as a number (e.g., 150, 5000)" not "How many employees."
+- **Include decision rules for ambiguous fields.** "Classify as 'Enterprise' if revenue > $100M OR employees > 1000."
+- **Constrain length.** "One sentence", "Under 50 words", "Under 6 words" — prevents rambling.
+- **Default to null, not hallucination.** Set `default: None` for fields where data may genuinely not exist. Bad data is worse than missing data.
+- **Include boundary examples.** For classification, show the edge cases and how to resolve them.
+- **Use bad_examples.** Steer away from vague outputs: `bad_examples: ["It depends", "N/A", "Various"]`.
+
+### Suggest Fields by Archetype
+
+**Account qualification:**
+| Field | Type | Notes |
+|-------|------|-------|
+| industry | enum | 8-12 categories + Other |
+| employee_count | str | "150+", "5000+" format |
+| annual_revenue | str | "$X.XM" or "$X.XB" format |
+| icp_fit | enum | Strong Fit / Moderate Fit / Weak Fit |
+| summary | str | One sentence, for sales team |
+| signals | List[String] | Recent funding, hiring, product launches |
+
+**Lead research:**
+| Field | Type | Notes |
+|-------|------|-------|
+| role_relevance | enum | Decision Maker / Influencer / End User / Not Relevant |
+| seniority | enum | C-Suite / VP / Director / Manager / IC |
+| department | enum | Engineering / Sales / Marketing / Product / Other |
+| personalization_hook | str | One sentence, specific to this person |
+
+**Company intelligence:**
+| Field | Type | Notes |
+|-------|------|-------|
+| tech_stack | List[String] | Known technologies |
+| funding_stage | enum | Pre-seed through IPO + Bootstrapped + Unknown |
+| recent_news | str | Under 50 words, most recent significant event |
+| competitors | List[String] | Top 3 competitors |
+| business_model | enum | SaaS / Marketplace / Services / Hardware / Other |
+
+Present fields as a table. Iterate with the user until confirmed.
+
+## Phase 3: Plan Pipeline Architecture
+
+Read [patterns.md](references/patterns.md) for detailed patterns and code examples.
+
+### Single Step vs Multi-Step Decision
+
+**Use a single step when:**
+- All fields are related and from the same context
+- No field depends on another field's output
+- Same model and grounding settings for everything
+
+**Use multiple steps when:**
+- Outputs feed into later steps (dependency chain)
+- Different models needed (cheap tagger + expensive researcher)
+- **Gate pattern**: Cheap classification filters rows before expensive enrichment
+- Different grounding needs (some fields need web search, others don't)
+
+### Recommend Patterns Proactively
+
+- **>5 fields across different concerns** → Split into multiple steps
+- **Qualification + deep research** → Gate pattern (saves 60-70% on non-qualifying rows)
+- **Company + person enrichment** → Chain pattern with `__` internal fields
+- **Multiple independent enrichment types** → Fan-out (parallel steps, no `depends_on`)
+
+## Phase 4: Configure the Pipeline
+
+Read [providers.md](references/providers.md) for model selection, kwargs, and grounding details.
+
+### Fetch Model Documentation (REQUIRED)
+
+**Before writing any pipeline code, you MUST fetch the official docs and cookbook for the selected model.** This ensures you know the latest API constraints (e.g., parameter restrictions, structured output compatibility) and prompt best practices. Do not rely solely on your training data — models and APIs change.
+
+**What to fetch, by provider:**
+
+| Provider | Docs to fetch | How |
+|----------|--------------|-----|
+| **Anthropic** (Claude models) | API docs + prompt engineering guide | `WebFetch` the Anthropic docs page for the model (e.g., `https://docs.anthropic.com/en/docs/about-claude/models`) and the extended thinking docs (`https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking`). Check for parameter constraints (temperature, thinking, structured outputs). |
+| **OpenAI** (GPT-4.1, o-series) | API docs + prompting cookbook | `WebFetch` the model's API reference and the prompting guide (e.g., `https://platform.openai.com/docs/guides/prompting`). Check for reasoning_effort compatibility, structured output support. |
+| **Google** (Gemini) | API docs + grounding details | `WebFetch` the Gemini API docs. Check grounding and structured output behavior. |
+
+**What to look for:**
+- **Parameter constraints** — Which parameters are valid together? (e.g., temperature restrictions with thinking/reasoning modes)
+- **Structured output support** — Does the model support JSON schema? Any incompatibilities with grounding or thinking?
+- **Prompt best practices** — How does this model handle instructions? (literal vs. inferential, XML vs. markdown, sandwich technique, etc.)
+- **Pricing** — Confirm current input/output token pricing for cost estimates.
+- **Known gotchas** — Any model-specific quirks that affect enrichment (e.g., refusal patterns, output length limits).
+
+Summarize key findings briefly before proceeding. If a doc fetch fails, fall back to [providers.md](references/providers.md) and [prompts.md](references/prompts.md) but warn the user that config may not reflect the latest API behavior.
+
+### Model Selection (recommend, don't just list)
+
+| Use Case | Recommended Model | Why |
+|----------|------------------|-----|
+| Default / most enrichment | `gpt-4.1-mini` | Best cost/quality for structured extraction |
+| Simple classification | `gpt-4.1-nano` | Cheapest, but unreliable for nuanced tasks |
+| Complex inference | `gpt-4.1` or `claude-sonnet-4-6` | Better reasoning, higher quality |
+| High-volume Anthropic | `claude-haiku-4-5` | Fast, cheap, good at structured output |
+| Needs latest data | Any model + `grounding=True` | Web search for time-sensitive info |
+
+### Prompt Crafting
+
+Read [prompts.md](references/prompts.md) for model-specific cookbook guidance, then **cross-reference with the docs you fetched above**. Key rules:
+- **GPT-4.1 is hyper-literal.** Instructions must be explicit. Sandwich important instructions at beginning AND end. Use markdown/XML for structure. No implicit reasoning.
+- **Claude prefers XML tags.** Less repetition needed. Good at following complex instructions.
+- **Always include fallback instructions.** "If information is unavailable, return null." Prevents hallucination.
+- Apply any model-specific prompting techniques discovered in the fetched docs.
+
+### Grounding / Web Search
+
+- **Enable when:** Time-sensitive data, niche/small companies, post-training-cutoff, verification-critical facts
+- **Skip when:** Classification from provided context, well-known entities, text transformation
+- **Tradeoff:** Grounding disables structured outputs on Anthropic/Google. Flag this to the user.
+- For OpenAI: `grounding=True` uses Responses API web search
+- For Anthropic: `grounding=True` uses citations (document-grounded, not web search)
+- For Google: `grounding=True` uses Google Search
+
+### Provider kwargs
+
+Reference [providers.md](references/providers.md) for the full inventory. Common ones:
+- **Anthropic adaptive thinking:** `provider_kwargs={"thinking": {"type": "adaptive"}, "output_config": {"effort": "low"}}` — only for complex inference steps. **IMPORTANT:** When thinking is enabled, `temperature` MUST be set to `1` on the LLMStep.
+- **OpenAI reasoning effort:** `provider_kwargs={"reasoning_effort": "medium"}` — only on reasoning models (o3, o4-mini, gpt-5.x), NOT gpt-4.1
+
+### Workers
+
+| Row Count | API Tier | Recommendation |
+|-----------|----------|---------------|
+| <100 | Any | 10 (default) |
+| 100-1000 | Standard | 10-20 |
+| 1000-10000 | Tier 3+ | 20-50 |
+| >10000 | Tier 5 | 50-200 |
+
+Ask about API tier if enriching >1000 rows.
+
+### Always Recommend
+
+- **Cache: ON** (default). "If it crashes at row 847, rows 1-846 are instant on restart."
+- **Checkpointing: ON** for >500 rows. Saves full DataFrame after each step.
+- **Batch mode** for >500 rows when latency isn't critical. 50% cost savings. `LLMStep(batch=True)`.
+- **Temperature: 0.0-0.2** for extraction/classification. Only raise for creative fields.
+- **`on_error="continue"`** (default). Don't let one bad row kill 999 good ones.
+- **Test first.** Always suggest running on 5-10 rows before the full dataset.
+
+## Phase 5: Present & Confirm
+
+**Before writing any code, present a structured summary:**
+
+```
+## Enrichment Plan
+
+**Input:** {filename} ({row_count} rows, columns: {columns})
+**Output:** {output_filename}
+
+### Fields
+| Field | Type | Step | Rationale |
+|-------|------|------|-----------|
+| ... | ... | ... | ... |
+
+### Pipeline
+| Step | Model | Grounding | Condition | Est. Cost |
+|------|-------|-----------|-----------|-----------|
+| ... | ... | ... | ... | ... |
+
+### Configuration
+- Workers: {n} | Cache: ON | Checkpoint: {on/off} | Batch: {on/off}
+- Est. total cost: ~${cost} | Est. time: ~{time}
+
+### Model Choice Rationale
+- {model} for {step}: {one-line reason}
+
+### Prompt Strategy
+- {model-specific notes, e.g. "GPT-4.1-mini: explicit instructions, markdown structure"}
+```
+
+**Cost estimation formula:** `rows x avg_input_tokens x input_price + rows x avg_output_tokens x output_price`. Enrichment averages ~500 input tokens and ~200 output tokens per row for a typical step. Adjust for grounding (2-3x input tokens).
+
+Ask: **"Any changes before I write the script?"**
+
+Accept amendments. If the user says it looks good, proceed to Phase 6.
+
+## Phase 6: Generate & Hand Off
+
+1. **Write the script** to a file (e.g., `enrich.py`). Include:
+   - Imports from `accrue` and `pandas`
+   - Pipeline definition with all configured steps
+   - `data = pd.read_csv("input.csv")` then `result = pipeline.run(data, config=config)` — `run()` accepts `DataFrame` or `list[dict]`, NOT file paths
+   - Output to CSV
+   - Print summary (row count, success rate, cost)
+2. **Install Accrue if needed.** Before running, ensure accrue is installed in the active venv. For non-OpenAI providers, install the extra: `uv pip install -e ".[anthropic]"` or `pip install accrue[anthropic]`. Check that the correct Python (3.10+) and venv are used.
+3. **Use `.env` for API keys.** Accrue auto-loads dotenv. Remind user to set their key.
+4. **Present the CLI command:**
+   ```
+   python enrich.py
+   ```
+5. **Suggest test-first:** "Run on a small subset first: `head -11 data/accounts.csv > data/test.csv` then point the script at `test.csv`."
+6. **After the run:** Suggest reviewing output, spot-checking 5-10 rows, and iterating on field definitions if quality is off.
+
+## Enrichment Best Practices (always apply)
+
+- **Filter before you enrich.** Don't burn tokens on rows that won't qualify.
+- **Constrain outputs.** Enums > free text. Short > long. Specific > vague.
+- **Always include escape hatches.** "Other", "Unknown", `default: None`.
+- **Cache by default.** Iteration is the norm, not the exception.
+- **Start small.** Test on 5-10 rows, review, adjust, then scale.
+- **One concern per step.** Split when fields need different models, grounding, or conditions.
+- **Prompt for absence.** Tell the LLM what to do when data is missing.
+- **Cost-aware design.** Cheap classification gates expensive research.
+- **Don't over-enrich.** Only add fields that drive a downstream decision or action.
+- **Separate company from person.** Enrich company data once per domain, reference from person records.

--- a/.claude/skills/accrue/references/api.md
+++ b/.claude/skills/accrue/references/api.md
@@ -1,0 +1,238 @@
+# Accrue API Reference
+
+## Public Exports
+
+```python
+from accrue import (
+    Pipeline, PipelineResult, LLMStep, FunctionStep,
+    EnrichmentConfig, EnrichmentHooks, FieldSpec, GroundingConfig,
+    Step, StepContext, StepResult, web_search,
+    CostSummary, RowError, EnrichmentError,
+    BatchCapableLLMClient, BatchRequest, BatchResult,
+)
+```
+
+## Pipeline
+
+```python
+Pipeline(steps: list[Step])
+```
+- Validates: no duplicate names, no circular deps, no missing deps
+- Builds execution DAG via topological sort — steps at same level run in parallel
+
+### Pipeline.run()
+
+```python
+def run(
+    self,
+    data: pd.DataFrame | list[dict[str, Any]],
+    config: EnrichmentConfig | None = None,
+    hooks: EnrichmentHooks | None = None,
+) -> PipelineResult
+```
+
+- Sync wrapper around `asyncio.run(self.run_async(...))`
+- Input must be a `pd.DataFrame` or `list[dict]` — load CSVs with `pd.read_csv()` first
+- Returns `PipelineResult`
+
+### PipelineResult
+
+```python
+@dataclass
+class PipelineResult:
+    data: pd.DataFrame | list[dict[str, Any]]
+    cost: CostSummary     # .total_tokens, .input_tokens, .output_tokens
+    errors: list[RowError] # row index + error message + step name
+```
+
+Access: `result.data`, `result.cost`, `result.errors`
+Success rate: `1 - len(result.errors) / len(result.data)`
+
+## LLMStep
+
+```python
+LLMStep(
+    name: str,
+    fields: list[str] | dict[str, str | dict],
+    depends_on: list[str] | None = None,
+    model: str = "gpt-4.1-mini",
+    temperature: float | None = None,        # Overrides config; default from config is 0.2
+    max_tokens: int | None = None,           # Overrides config; default from config is 4000
+    system_prompt: str | None = None,        # Fully replaces auto-generated prompt
+    system_prompt_header: str | None = None, # Injected into auto-generated prompt
+    api_key: str | None = None,              # Provider API key
+    base_url: str | None = None,             # OpenAI-compatible endpoint
+    client: LLMClient | None = None,         # Pre-configured provider client
+    schema: Type[BaseModel] = EnrichmentResult,  # Custom Pydantic validation
+    max_retries: int = 2,
+    cache: bool = True,                      # Per-step cache toggle
+    structured_outputs: bool | None = None,  # None = auto-detect
+    grounding: bool | dict | GroundingConfig | None = None,
+    sources_field: str | None = "sources",   # Where citations go; None to suppress
+    run_if: Callable | None = None,          # (row, prior_results) -> bool
+    skip_if: Callable | None = None,         # (row, prior_results) -> bool; mutually exclusive with run_if
+    batch: bool = False,                     # Use provider batch API
+    provider_kwargs: dict[str, Any] | None = None,  # Escape hatch; merged into API call; NOT in cache key
+)
+```
+
+### System Prompt Tiers
+
+1. **Default** — Auto-generated from field specs + row data. No config needed.
+2. **`system_prompt_header`** — Injected as context within auto-generated prompt. Use for domain knowledge.
+3. **`system_prompt`** — Fully replaces auto-generated prompt. You must instruct LLM to return JSON matching field names.
+
+`system_prompt_header` is ignored when `system_prompt` is set.
+
+## FunctionStep
+
+```python
+FunctionStep(
+    name: str,
+    fn: Callable,           # async def fn(row: dict, context: StepContext) -> dict
+    fields: list[str],      # Field names this step produces
+    depends_on: list[str] | None = None,
+    cache: bool = True,
+    cache_version: str | None = None,  # Bump to invalidate cache
+    run_if: Callable | None = None,
+    skip_if: Callable | None = None,
+)
+```
+
+Use for: data cleaning, API calls, computations, validation — anything that's not an LLM call.
+
+## EnrichmentConfig
+
+```python
+EnrichmentConfig(
+    # LLM
+    max_tokens: int = 4000,
+    temperature: float = 0.2,
+    # Concurrency
+    max_workers: int = 10,
+    # Fields
+    overwrite_fields: bool = False,
+    # Reliability
+    max_retries: int = 3,
+    retry_base_delay: float = 1.0,
+    on_error: str = "continue",        # "continue" | "raise"
+    # Logging
+    log_level: str = "INFO",
+    enable_progress_bar: bool = True,
+    # Checkpointing
+    enable_checkpointing: bool = False,
+    checkpoint_dir: str | None = None,
+    auto_resume: bool = True,
+    # Caching
+    enable_caching: bool = False,
+    cache_ttl: int = 3600,             # Seconds
+    cache_dir: str = ".accrue",
+    checkpoint_interval: int = 0,
+    # Batch API
+    batch_poll_interval: float = 60.0,
+    batch_timeout: float = 86400.0,    # 24 hours
+    batch_max_requests: int = 50000,
+)
+```
+
+**Important:** `enable_caching` on config is the global toggle. `cache` on LLMStep/FunctionStep is per-step. Both must be True for caching to work. Steps default to `cache=True`, so typically you just set `enable_caching=True` on config.
+
+## FieldSpec (7 keys)
+
+```python
+class FieldSpec(BaseModel):
+    prompt: str                    # Required. Extraction instruction.
+    type: str = "String"           # String | Number | Boolean | Date | List[String] | JSON
+    format: str | None = None      # Output format pattern, e.g. "$X.XB", "YYYY-MM-DD"
+    enum: list[str] | None = None  # Constrained values. LLM must pick from this set.
+    examples: list[str] | None     # Good output examples
+    bad_examples: list[str] | None # Anti-patterns to avoid
+    default: Any = None            # Fallback for LLM refusals ("N/A", "Unable to determine")
+```
+
+**Shorthand forms:**
+- String value → `{"prompt": "the string"}`
+- Dict value → Full FieldSpec
+- List of strings → Field names only (no specs, prompts come from context)
+
+## GroundingConfig
+
+```python
+GroundingConfig(
+    allowed_domains: list[str] | None = None,   # Restrict web search to these domains
+    blocked_domains: list[str] | None = None,
+    user_location: dict[str, str] | None = None, # {"country": "US", "city": "San Francisco"}
+    max_searches: int | None = None,
+    provider_kwargs: dict[str, Any] | None = None,
+)
+```
+
+Shorthand: `grounding=True` → `GroundingConfig()` with all defaults.
+
+**Provider behavior:**
+- OpenAI: Responses API web search tool
+- Anthropic: Citations (document-grounded, not web search)
+- Google: Google Search grounding
+- **Grounding disables structured outputs on Anthropic/Google.** OpenAI is unaffected.
+
+## EnrichmentHooks
+
+```python
+EnrichmentHooks(
+    on_pipeline_start: Callable[[PipelineStartEvent], Any] | None = None,
+    on_pipeline_end: Callable[[PipelineEndEvent], Any] | None = None,
+    on_step_start: Callable[[StepStartEvent], Any] | None = None,
+    on_step_end: Callable[[StepEndEvent], Any] | None = None,
+    on_row_complete: Callable[[RowCompleteEvent], Any] | None = None,
+)
+```
+
+Sync and async callables both work. Hook errors are caught and logged — never crash the pipeline.
+
+## Conditional Steps
+
+```python
+# Predicate signature
+def predicate(row: dict, prior_results: dict) -> bool
+
+# Usage
+LLMStep("deep_dive",
+    fields={...},
+    depends_on=["classify"],
+    run_if=lambda row, prior: prior.get("tier") == "enterprise",
+)
+```
+
+- `run_if` and `skip_if` are mutually exclusive
+- Predicates run before cache checks — skipped rows never hit cache or API
+- Skipped rows get `None` or the field's `default` value
+
+## Internal Fields (__ prefix)
+
+Fields prefixed with `__` are passed between steps but filtered from final output:
+
+```python
+LLMStep("research",
+    fields={"__company_context": "Detailed company background for later steps"},
+)
+LLMStep("qualify",
+    fields={"icp_fit": "Qualify based on company context"},
+    depends_on=["research"],
+    # __company_context is available in prior_results but won't appear in output
+)
+```
+
+## web_search() Factory
+
+```python
+from accrue import web_search
+
+step = web_search(
+    name="find_info",
+    query_template="What does {company_name} do?",
+    fields={"answer": "Company description"},
+    model="gpt-4.1-mini",
+)
+```
+
+Convenience factory that returns an LLMStep with grounding pre-configured.

--- a/.claude/skills/accrue/references/patterns.md
+++ b/.claude/skills/accrue/references/patterns.md
@@ -1,0 +1,262 @@
+# Pipeline Architecture Patterns
+
+## Single-Step Enrichment
+
+Use when all fields are related, same model, same grounding, no dependencies.
+
+```python
+from accrue import Pipeline, LLMStep, EnrichmentConfig
+
+pipeline = Pipeline([
+    LLMStep("qualify",
+        system_prompt_header="You are qualifying B2B accounts for sales outreach.",
+        fields={
+            "industry": {"prompt": "Primary industry", "enum": [...]},
+            "employee_count": {"prompt": "Estimated headcount", "examples": ["500+"]},
+            "icp_fit": {"prompt": "ICP fit assessment", "enum": ["Strong", "Moderate", "Weak"]},
+            "summary": {"prompt": "One-sentence summary, under 25 words"},
+        },
+        model="gpt-4.1-mini",
+    ),
+])
+
+config = EnrichmentConfig(enable_caching=True, enable_checkpointing=True)
+data = pd.read_csv("accounts.csv")
+result = pipeline.run(data, config=config)
+result.data.to_csv("enriched.csv", index=False)
+```
+
+## Gate Pattern (Cost Optimization)
+
+Cheap classification step filters rows before expensive enrichment. If 30% of rows qualify, you save 70% on the expensive step.
+
+```python
+pipeline = Pipeline([
+    # Step 1: Cheap classifier (runs on ALL rows)
+    LLMStep("classify",
+        fields={
+            "tier": {
+                "prompt": "Classify company tier. Enterprise = >1000 employees or >$100M revenue. Mid-Market = 100-1000 employees. SMB = <100 employees.",
+                "enum": ["Enterprise", "Mid-Market", "SMB"],
+            },
+        },
+        model="gpt-4.1-nano",  # Cheapest model for simple classification
+        temperature=0.0,
+    ),
+    # Step 2: Expensive research (ONLY on Enterprise rows)
+    LLMStep("deep_research",
+        fields={
+            "competitive_landscape": {"prompt": "Detailed competitive analysis", "default": "Not available"},
+            "growth_signals": {"prompt": "Recent growth signals (funding, hiring, expansion)", "type": "List[String]", "default": None},
+            "decision_makers": {"prompt": "Key decision makers and their roles", "type": "List[String]", "default": None},
+        },
+        depends_on=["classify"],
+        run_if=lambda row, prior: prior.get("tier") == "Enterprise",
+        model="gpt-4.1",
+        grounding=True,  # Web search for current data
+    ),
+])
+```
+
+**Cost math:** 1000 rows. Step 1: 1000 x gpt-4.1-nano = ~$0.10. Step 2 (30% qualify): 300 x gpt-4.1 + grounding = ~$1.56. **Total: ~$1.66** vs ~$5.20 without gating.
+
+## Fan-Out (Parallel Independent Steps)
+
+Steps without `depends_on` relationships run in parallel automatically.
+
+```python
+pipeline = Pipeline([
+    # These 3 steps run in parallel (no depends_on between them)
+    LLMStep("firmographics",
+        fields={
+            "industry": {"prompt": "Primary industry", "enum": [...]},
+            "employee_count": {"prompt": "Estimated headcount"},
+            "hq_location": {"prompt": "Headquarters city and country"},
+        },
+        model="gpt-4.1-mini",
+    ),
+    LLMStep("technographics",
+        fields={
+            "tech_stack": {"prompt": "Known technologies used", "type": "List[String]"},
+            "cloud_provider": {"prompt": "Primary cloud (AWS/GCP/Azure/Other)", "enum": [...]},
+        },
+        model="gpt-4.1-mini",
+        grounding=True,  # Tech stack needs current data
+    ),
+    LLMStep("news",
+        fields={
+            "recent_news": {"prompt": "Most recent significant company news, under 50 words", "default": None},
+            "funding_stage": {"prompt": "Latest funding round", "enum": ["Seed", "Series A", "Series B", "Series C+", "IPO", "Bootstrapped", "Unknown"]},
+        },
+        model="gpt-4.1-mini",
+        grounding=True,
+    ),
+    # This step waits for all 3 above
+    LLMStep("synthesize",
+        fields={
+            "icp_fit": {"prompt": "Based on firmographics, tech stack, and news, assess overall ICP fit", "enum": ["Strong", "Moderate", "Weak"]},
+            "outreach_angle": {"prompt": "Suggested sales angle based on all available data, one sentence"},
+        },
+        depends_on=["firmographics", "technographics", "news"],
+        model="gpt-4.1",  # Needs reasoning to synthesize
+    ),
+])
+```
+
+## Chain Pattern (Internal Fields)
+
+Pass context between steps using `__` prefixed internal fields. These are available to downstream steps but filtered from final output.
+
+```python
+pipeline = Pipeline([
+    LLMStep("company_research",
+        fields={
+            "__company_context": "Comprehensive company background including products, market position, recent developments. 2-3 paragraphs.",
+            "industry": {"prompt": "Primary industry", "enum": [...]},
+            "company_size": {"prompt": "Company size category", "enum": ["Startup", "SMB", "Mid-Market", "Enterprise"]},
+        },
+        model="gpt-4.1-mini",
+        grounding=True,
+    ),
+    LLMStep("person_research",
+        fields={
+            "role_fit": {"prompt": "Based on the company context and this person's role, assess relevance to our product", "enum": ["High", "Medium", "Low"]},
+            "personalization": {"prompt": "One sentence personalized to both the person and their company context"},
+        },
+        depends_on=["company_research"],
+        model="gpt-4.1-mini",
+        # __company_context is automatically available in prior_results
+    ),
+])
+```
+
+## Conditional Enrichment (run_if / skip_if)
+
+### Skip Bad Data
+
+```python
+LLMStep("enrich",
+    fields={"summary": "Company summary"},
+    skip_if=lambda row, prior: not row.get("company_name") or not row.get("website"),
+)
+```
+
+### Tiered Enrichment
+
+```python
+pipeline = Pipeline([
+    LLMStep("classify",
+        fields={"priority": {"prompt": "Priority tier", "enum": ["High", "Medium", "Low"]}},
+    ),
+    LLMStep("basic_info",
+        fields={"summary": "One-sentence summary"},
+        depends_on=["classify"],
+        # Runs for all classified rows (Medium and High)
+        skip_if=lambda row, prior: prior.get("priority") == "Low",
+    ),
+    LLMStep("premium_research",
+        fields={
+            "competitive_analysis": {"prompt": "Detailed competitive analysis", "default": "N/A"},
+            "buying_signals": {"prompt": "Active buying signals", "type": "List[String]", "default": None},
+        },
+        depends_on=["classify"],
+        run_if=lambda row, prior: prior.get("priority") == "High",
+        model="gpt-4.1",
+        grounding=True,
+    ),
+])
+```
+
+## FunctionStep for Pre/Post Processing
+
+Use FunctionStep for non-LLM operations: data cleaning, API calls, computations.
+
+```python
+from accrue import Pipeline, LLMStep, FunctionStep, StepContext
+
+async def clean_domain(row: dict, context: StepContext) -> dict:
+    """Extract clean domain from website URL."""
+    website = row.get("website", "")
+    domain = website.replace("https://", "").replace("http://", "").replace("www.", "").strip("/")
+    return {"clean_domain": domain}
+
+async def compute_score(row: dict, context: StepContext) -> dict:
+    """Compute composite score from enriched fields."""
+    weights = {"Strong Fit": 3, "Moderate Fit": 2, "Weak Fit": 1}
+    icp_score = weights.get(context.prior_results.get("icp_fit", ""), 0)
+    has_signals = len(context.prior_results.get("signals", []) or []) > 0
+    return {"composite_score": icp_score + (1 if has_signals else 0)}
+
+pipeline = Pipeline([
+    FunctionStep("clean", fn=clean_domain, fields=["clean_domain"]),
+    LLMStep("enrich", fields={...}, depends_on=["clean"]),
+    FunctionStep("score", fn=compute_score, fields=["composite_score"], depends_on=["enrich"]),
+])
+```
+
+## Batch Mode
+
+For large datasets where latency isn't critical. 50% cost savings.
+
+```python
+pipeline = Pipeline([
+    LLMStep("enrich",
+        fields={...},
+        model="gpt-4.1-mini",
+        batch=True,  # That's it
+    ),
+])
+
+config = EnrichmentConfig(
+    enable_caching=True,
+    enable_checkpointing=True,
+    batch_poll_interval=60.0,   # Check every 60s (default)
+    batch_timeout=86400.0,      # 24h max (default)
+)
+data = pd.read_csv("large_dataset.csv")
+result = pipeline.run(data, config=config)
+```
+
+- Cache-aware: only uncached rows are sent to batch
+- Auto-chunks at 50,000 requests per batch
+- Failed rows automatically fall back to realtime
+- Available on OpenAI and Anthropic only
+
+## Incremental Enrichment
+
+Adding new fields to already-enriched data without re-running existing fields.
+
+```python
+# Round 1: Basic enrichment
+pipeline_v1 = Pipeline([
+    LLMStep("basic", fields={"industry": "...", "size": "..."}),
+])
+result = pipeline_v1.run("accounts.csv", config=EnrichmentConfig(enable_caching=True))
+result.data.to_csv("enriched_v1.csv", index=False)
+
+# Round 2: Add new fields (industry and size already cached)
+pipeline_v2 = Pipeline([
+    LLMStep("basic", fields={"industry": "...", "size": "...", "icp_fit": "..."}),
+    # Cache will serve industry and size; only icp_fit hits the API
+    # NOTE: Adding a field changes the cache key, so all rows will re-run.
+    # To avoid this, add icp_fit as a separate step:
+])
+
+# Better approach: new step for new fields
+pipeline_v2 = Pipeline([
+    LLMStep("basic", fields={"industry": "...", "size": "..."}),  # 100% cache hits
+    LLMStep("scoring", fields={"icp_fit": "..."}, depends_on=["basic"]),  # Only this runs
+])
+```
+
+**Key insight:** Cache keys include the prompt + field spec + model. Changing any of these invalidates the cache for that step. To preserve cache, add new fields as new steps rather than expanding existing ones.
+
+## Configuration Recommendations by Scale
+
+| Rows | Workers | Cache | Checkpoint | Batch | Est. Time (gpt-4.1-mini) |
+|------|---------|-------|------------|-------|--------------------------|
+| 10 | 10 | Yes | No | No | ~5s |
+| 100 | 10 | Yes | No | No | ~30s |
+| 1,000 | 20 | Yes | Yes | Consider | ~5 min |
+| 10,000 | 50 | Yes | Yes | Yes | ~50 min (batch: hours) |
+| 50,000 | 100 | Yes | Yes | Yes | ~4 hours (batch: hours) |

--- a/.claude/skills/accrue/references/prompts.md
+++ b/.claude/skills/accrue/references/prompts.md
@@ -1,0 +1,179 @@
+# Prompt Cookbook for Enrichment
+
+## The S.P.I.C.E. Framework (adapted for Accrue)
+
+Structure enrichment prompts with these components:
+
+1. **Specifics** — What exact output you want (field names, formats, constraints)
+2. **Persona** — Role context via `system_prompt_header` ("You are a B2B sales analyst...")
+3. **Instructions** — Step-by-step extraction rules, decision criteria, fallback behavior
+4. **Context** — Row data injected automatically via `{column_name}` placeholders
+5. **Examples** — Few-shot via `examples` and `bad_examples` in field specs
+
+In Accrue, most of this is handled by the field spec system. The LLM receives an auto-generated prompt containing all field definitions. Use `system_prompt_header` for additional context.
+
+## Model-Specific Guidance
+
+### GPT-4.1 / GPT-4.1-mini (OpenAI)
+
+GPT-4.1 follows instructions **hyper-literally** compared to GPT-4o. Adapt accordingly:
+
+- **Be explicit.** Don't rely on implicit understanding. If you want reasoning, ask for it.
+- **Sandwich method.** Place critical instructions at BOTH the beginning and end of long context.
+- **Markdown/XML > JSON** for document structure in prompts. JSON performs "particularly poorly" for long-context tasks.
+- **No built-in reasoning.** Must explicitly prompt for chain-of-thought if needed.
+- **Use the tools API** exclusively for function calling — don't inject tool descriptions into prompts.
+- **Structured outputs work natively** via `json_schema` with `strict: true`. Accrue handles this automatically.
+
+**Good GPT-4.1 enrichment prompt style:**
+```python
+system_prompt_header="""You are a B2B company analyst. For each company, extract structured data.
+
+RULES:
+- If data is unavailable, return null — never guess
+- Employee counts should be estimates with + suffix (e.g., "500+")
+- Industry must be one of the enum values provided
+- Summary must be exactly one sentence, under 30 words
+
+IMPORTANT: Return null for any field where you lack confidence."""
+```
+
+### Claude (Anthropic)
+
+- **XML tags preferred.** Claude responds well to `<instructions>`, `<context>`, `<output_format>` tags.
+- **Less repetition needed.** Claude follows complex instructions well without sandwiching.
+- **System prompt for persona.** Claude uses system prompt role-setting effectively.
+- **Prompt caching is automatic** in Accrue — system messages get `cache_control`.
+
+**Good Claude enrichment prompt style:**
+```python
+system_prompt_header="""<role>B2B company analyst</role>
+
+<instructions>
+Extract structured company data. Follow these rules:
+- Return null when data is genuinely unavailable
+- Employee counts: estimates with + suffix (e.g., "500+")
+- Summary: exactly one sentence, under 30 words
+</instructions>"""
+```
+
+### Gemini (Google)
+
+- Follows OpenAI-style prompting conventions
+- Strong at grounding with Google Search
+- Use clear, direct instructions
+
+## Enrichment Prompt Templates
+
+### Account Qualification
+
+```python
+LLMStep("qualify",
+    system_prompt_header="You are qualifying B2B SaaS accounts for sales outreach. Be concise and factual.",
+    fields={
+        "industry": {
+            "prompt": "Primary industry category for this company",
+            "enum": ["Fintech", "Developer Tools", "Cybersecurity", "Data & Analytics",
+                     "Cloud Infrastructure", "HR Tech", "Sales & Marketing", "Healthcare",
+                     "E-commerce", "Other"],
+        },
+        "employee_count": {
+            "prompt": "Estimated total employee count. Use format like '500+' or '5000+'",
+            "examples": ["150+", "2000+", "50000+"],
+            "bad_examples": ["a lot", "large company", "unknown"],
+            "default": None,
+        },
+        "icp_fit": {
+            "prompt": "How well does this company fit as a B2B SaaS prospect? Strong Fit = enterprise with >500 employees in tech. Moderate = mid-market or adjacent industry. Weak = SMB, consumer, or no tech buying signals.",
+            "enum": ["Strong Fit", "Moderate Fit", "Weak Fit"],
+        },
+        "summary": {
+            "prompt": "One-sentence company summary for a sales team. Under 25 words.",
+            "examples": ["Enterprise cloud security platform serving Fortune 500 companies"],
+            "bad_examples": ["Stripe is a company that does payments and stuff"],
+        },
+    },
+    model="gpt-4.1-mini",
+)
+```
+
+### Lead Research
+
+```python
+LLMStep("research_lead",
+    system_prompt_header="You are researching sales leads. Extract role and relevance data.",
+    fields={
+        "role_relevance": {
+            "prompt": "Is this person relevant to a B2B software sale? Decision Maker = budget authority. Influencer = technical evaluator. End User = daily user. Not Relevant = wrong department or role.",
+            "enum": ["Decision Maker", "Influencer", "End User", "Not Relevant"],
+        },
+        "seniority": {
+            "prompt": "Seniority level based on job title",
+            "enum": ["C-Suite", "VP", "Director", "Manager", "IC", "Unknown"],
+        },
+        "personalization_hook": {
+            "prompt": "One specific, non-generic thing about this person that could start a conversation. Reference their work, background, or company. Under 20 words.",
+            "examples": ["Led the migration from on-prem to AWS at their previous company"],
+            "bad_examples": ["They work in tech", "Experienced professional"],
+            "default": None,
+        },
+    },
+)
+```
+
+### Classification / Tagging
+
+```python
+LLMStep("classify",
+    system_prompt_header="Classify each record into categories. Be consistent — same input should always produce same output.",
+    fields={
+        "category": {
+            "prompt": "Primary content category",
+            "enum": ["Product Update", "Thought Leadership", "Case Study", "Tutorial", "News", "Other"],
+        },
+        "sentiment": {
+            "prompt": "Overall sentiment of the content",
+            "enum": ["Positive", "Neutral", "Negative"],
+        },
+        "relevance_score": {
+            "prompt": "How relevant is this to our product (1-5). 5 = directly about our space. 1 = unrelated.",
+            "type": "Number",
+        },
+    },
+    model="gpt-4.1-nano",  # Simple classification = cheapest model
+    temperature=0.0,         # Deterministic
+)
+```
+
+### Content Extraction
+
+```python
+LLMStep("extract",
+    system_prompt_header="""Extract structured data from the provided text.
+Rules: Only extract information explicitly stated. Never infer or guess.
+If a field is not mentioned in the text, return null.""",
+    fields={
+        "company_name": {"prompt": "Company name mentioned in text", "default": None},
+        "deal_size": {"prompt": "Dollar amount of deal/contract", "format": "$X.XM", "default": None},
+        "key_people": {"prompt": "Names and titles of people mentioned", "type": "List[String]"},
+    },
+)
+```
+
+## Prompt Anti-Patterns
+
+| Anti-Pattern | Problem | Fix |
+|-------------|---------|-----|
+| "Tell me about this company" | Too vague, LLM rambles | Specific field prompts with length constraints |
+| No fallback instruction | LLM hallucinates when unsure | Add `default: None` and "return null if unavailable" |
+| Ambiguous enum categories | Inconsistent classification | Add decision rules with boundary examples |
+| 20+ fields in one step | Instruction neglect / contextual drift | Split into focused steps |
+| "Be creative" in enrichment | Inconsistent outputs | Lower temperature, constrain format |
+| No examples | LLM guesses at desired format | Add 2-3 examples and bad_examples |
+
+## When to Use system_prompt vs system_prompt_header
+
+- **`system_prompt_header`** (recommended): Adds context to the auto-generated prompt. Field specs still format automatically. Use for persona, rules, and domain knowledge.
+- **`system_prompt`**: Fully replaces the auto-generated prompt. You must instruct the LLM to return JSON with field names. Use only when the auto-generated prompt doesn't fit your needs.
+
+Most enrichment should use `system_prompt_header`. Only reach for `system_prompt` when you need full control.

--- a/.claude/skills/accrue/references/providers.md
+++ b/.claude/skills/accrue/references/providers.md
@@ -1,0 +1,209 @@
+# Model Selection & Provider Configuration
+
+## Model Comparison for Enrichment
+
+> **Last verified: 2026-03-26.** Pricing changes frequently — confirm at [OpenAI](https://openai.com/api/pricing/), [Anthropic](https://docs.anthropic.com/en/docs/about-claude/pricing), [Google](https://ai.google.dev/gemini-api/docs/pricing) before relying on estimates.
+
+| Model | Provider | Cost (in/out per MTok) | Context | Best For |
+|-------|----------|----------------------|---------|----------|
+| `gpt-4.1-nano` | OpenAI | $0.10 / $0.40 | 1M | Simple classification, tagging |
+| `gpt-4.1-mini` | OpenAI | $0.40 / $1.60 | 1M | **Default for most enrichment** |
+| `gpt-4.1` | OpenAI | $2.00 / $8.00 | 1M | Complex inference, high-quality extraction |
+| `claude-haiku-4-5` | Anthropic | $1.00 / $5.00 | 200K | High-volume structured extraction |
+| `claude-sonnet-4-6` | Anthropic | $3.00 / $15.00 | 1M | Quality + reasoning, adaptive thinking |
+| `claude-opus-4-6` | Anthropic | $5.00 / $25.00 | 1M | Maximum quality, complex analysis |
+| `gemini-2.5-flash` | Google | $0.30 / $2.50 | 1M | Google Search grounding (note: output price includes thinking tokens) |
+| `o4-mini` | OpenAI | $1.10 / $4.40 | 200K | Tasks requiring step-by-step reasoning |
+
+### Selection Decision Tree
+
+1. **Is it simple classification/tagging?** → `gpt-4.1-nano` (cheapest)
+2. **Standard enrichment (company research, qualification)?** → `gpt-4.1-mini` (default)
+3. **Needs reasoning or nuance?** → `gpt-4.1` or `claude-sonnet-4-6`
+4. **Needs latest real-time data?** → Any model + `grounding=True`
+5. **High-volume (>10K rows), cost-sensitive?** → `gpt-4.1-nano` or `gemini-2.5-flash`
+6. **Anthropic preferred?** → `claude-haiku-4-5` (volume) or `claude-sonnet-4-6` (quality)
+
+## Provider Setup
+
+### OpenAI (default, no extra install)
+
+```python
+# Set OPENAI_API_KEY in .env (auto-loaded by Accrue)
+LLMStep("analyze", fields={...}, model="gpt-4.1-mini")
+```
+
+### Anthropic
+
+```bash
+pip install accrue[anthropic]
+```
+
+```python
+from accrue.providers import AnthropicClient
+LLMStep("analyze", fields={...}, model="claude-sonnet-4-6", client=AnthropicClient())
+```
+
+Set `ANTHROPIC_API_KEY` in .env.
+
+### Google
+
+```bash
+pip install accrue[google]
+```
+
+```python
+from accrue.providers import GoogleClient
+LLMStep("analyze", fields={...}, model="gemini-2.5-flash", client=GoogleClient())
+```
+
+Set `GOOGLE_API_KEY` in .env.
+
+### OpenAI-Compatible (Ollama, Groq, Together, etc.)
+
+```python
+LLMStep("analyze", fields={...}, model="llama3",
+        base_url="http://localhost:11434/v1")
+```
+
+Note: `base_url` switches from Responses API to Chat Completions. No web search. Structured outputs fall back to `json_object`.
+
+## Provider-Specific Features (provider_kwargs)
+
+### OpenAI
+
+```python
+# Reasoning effort (ONLY on reasoning models: o3, o4-mini, gpt-5.x — NOT gpt-4.1)
+provider_kwargs={"reasoning_effort": "medium"}  # low | medium | high
+
+# Disable storage (privacy-sensitive data)
+provider_kwargs={"store": False}
+```
+
+### Anthropic
+
+```python
+# Adaptive thinking (Opus 4.6 and Sonnet 4.6 only)
+# Use for complex inference steps; skip for simple extraction
+# IMPORTANT: temperature MUST be set to 1 when thinking is enabled
+provider_kwargs={
+    "thinking": {"type": "adaptive"},
+    "output_config": {"effort": "low"},  # low | medium | high | max (Opus only)
+}
+# When using adaptive thinking, set temperature=1 on the LLMStep
+
+# Hide thinking output (faster time-to-first-token, same cost)
+provider_kwargs={
+    "thinking": {"type": "adaptive", "display": "omitted"},
+}
+```
+
+**Prompt caching** is automatic in Accrue — `cache_control: {"type": "ephemeral"}` is added to system messages. ~90% savings on repeated system prompt tokens.
+
+Cache thresholds (minimum tokens for caching to activate):
+- Opus 4.6: 4,096 tokens
+- Sonnet 4.6: 2,048 tokens
+- Sonnet 4.5: 1,024 tokens
+
+### Google
+
+No special provider_kwargs currently. Grounding uses Google Search natively.
+
+## Grounding / Web Search
+
+### When to Enable
+
+| Scenario | Grounding? | Why |
+|----------|-----------|-----|
+| Time-sensitive data (funding, news, headcount) | Yes | Model knowledge has a cutoff |
+| Niche/small companies (<100 employees) | Yes | Model unlikely to know them |
+| Well-known companies (FAANG, unicorns) | No | Model knowledge is sufficient |
+| Classification from provided context | No | No external data needed |
+| Text transformation/extraction | No | Working with existing text |
+| Verifying factual claims | Yes | Ground truth matters |
+
+### Configuration
+
+```python
+# Simple: enable defaults
+LLMStep("research", fields={...}, grounding=True)
+
+# Advanced: restrict to specific domains
+LLMStep("research", fields={...}, grounding=GroundingConfig(
+    allowed_domains=["crunchbase.com", "linkedin.com", "pitchbook.com"],
+    max_searches=3,
+))
+```
+
+### Provider Behavior
+
+| Provider | Grounding Implementation | Structured Outputs |
+|----------|------------------------|-------------------|
+| OpenAI | Responses API web search | Works normally |
+| Anthropic | Citations (document-grounded) | **Disabled** (incompatible) |
+| Google | Google Search | **Disabled** (incompatible) |
+
+**Critical tradeoff:** On Anthropic and Google, enabling grounding disables structured outputs. The LLM returns JSON in a text block instead of structured tool output. Accrue handles parsing, but quality may be slightly lower. Flag this to the user.
+
+### Citations
+
+When grounding is active, citations are stored in a `sources` field by default:
+
+```python
+LLMStep("research", fields={...}, grounding=True, sources_field="sources")
+# sources_field=None to suppress citations
+```
+
+## Batch API
+
+50% cost savings. Available on OpenAI and Anthropic.
+
+```python
+LLMStep("enrich", fields={...}, batch=True)
+```
+
+- 24-hour processing window (not for time-critical work)
+- Auto-chunks at 50,000 requests
+- Cache-aware: only uncached rows go to batch
+- Failed batch rows automatically fall back to realtime
+- Configure via `EnrichmentConfig(batch_poll_interval=60, batch_timeout=86400)`
+
+### When to Use Batch
+
+| Row Count | Latency OK? | Recommendation |
+|-----------|------------|---------------|
+| <100 | — | Realtime (batch overhead not worth it) |
+| 100-500 | Yes | Consider batch for cost savings |
+| >500 | Yes | Definitely batch |
+| Any | No, need results fast | Realtime |
+
+## Cost Estimation
+
+**Formula:** `rows x avg_input_tokens x input_price + rows x avg_output_tokens x output_price`
+
+**Typical enrichment tokens per row:**
+- Input: ~500 tokens (system prompt + row data + field specs)
+- Output: ~200 tokens (structured JSON response)
+- With grounding: 2-3x input tokens (search results injected)
+
+**Quick estimates for 1000 rows, single step:**
+
+| Model | Est. Cost (realtime) | Est. Cost (batch) |
+|-------|---------------------|-------------------|
+| gpt-4.1-nano | ~$0.10 | ~$0.05 |
+| gpt-4.1-mini | ~$0.50 | ~$0.25 |
+| gpt-4.1 | ~$2.60 | ~$1.30 |
+| claude-haiku-4-5 | ~$1.50 | ~$0.75 |
+| claude-sonnet-4-6 | ~$4.50 | ~$2.25 |
+
+Multiply by number of steps. Gate patterns reduce cost proportionally to the pass-through rate.
+
+## Feature Comparison
+
+| Feature | OpenAI | Anthropic | Google | OpenAI-Compatible |
+|---------|--------|-----------|--------|-------------------|
+| Structured outputs | json_schema | Constrained decoding | json_schema | json_object |
+| Grounding / web search | Yes | Yes (citations) | Yes (Google Search) | No |
+| Batch API | Yes | Yes | No | No |
+| Prompt caching | No | Automatic | No | No |
+| Reasoning / thinking | o3/o4-mini/gpt-5.x | Adaptive thinking | No | Varies |

--- a/.gitignore
+++ b/.gitignore
@@ -103,7 +103,6 @@ cython_debug/
 # Accrue project-specific
 .notes/
 .accrue/
-.claude/
 docs/_archive/
 enriched_*.csv
 output_*.csv

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ pip install accrue[anthropic]  # Claude
 pip install accrue[google]     # Gemini
 ```
 
+## Claude Code Skill
+
+If you use [Claude Code](https://claude.ai/claude-code), Accrue ships with a built-in `/accrue` skill that guides you through building pipelines interactively. It designs fields, picks models, estimates costs, and writes your script -- you just review and run.
+
+```
+> /accrue
+> I have 500 companies in accounts.csv, I need to qualify them for ICP fit
+```
+
+The skill walks you through field design, model selection, pipeline architecture, and configuration before writing a production-ready script. See [Using the Claude Code Skill](docs/getting-started/claude-code-skill.md) for details.
+
 ## Why Accrue
 
 You have a spreadsheet of companies, leads, or entities. You need structured fields added to every row -- classifications, summaries, scores, extracted data. You could write a `for` loop and call the OpenAI API, but then you're building retry logic, rate limiting, caching, progress tracking, and crash recovery. You could use Clay, but you'd pay $500/month for something you can't version-control.
@@ -139,6 +150,7 @@ With `batch=True`, halve the API costs. Cached steps re-run in seconds.
 | Section | Description |
 |---------|-------------|
 | [Getting Started](docs/getting-started/quickstart.md) | Installation, first pipeline, core concepts |
+| [Claude Code Skill](docs/getting-started/claude-code-skill.md) | Interactive pipeline builder via `/accrue` |
 | [Guides](docs/guides/) | Field specs, providers, caching, batch API, grounding, hooks, errors, configuration |
 | [Cookbook](docs/cookbook/) | End-to-end examples: [company enrichment](docs/cookbook/company-enrichment.md), [lead scoring](docs/cookbook/lead-scoring.md), [content analysis](docs/cookbook/content-analysis.md), [batch processing](docs/cookbook/batch-processing.md) |
 | [API Reference](docs/reference/api.md) | Complete reference for every public export |

--- a/docs/getting-started/claude-code-skill.md
+++ b/docs/getting-started/claude-code-skill.md
@@ -1,0 +1,128 @@
+# Using the Claude Code Skill
+
+Accrue ships with a built-in [Claude Code](https://claude.ai/claude-code) skill that guides you through building enrichment pipelines interactively. Instead of writing pipeline code from scratch, you describe what you want and the skill designs fields, picks models, estimates costs, and writes a production-ready script.
+
+## Prerequisites
+
+- [Claude Code](https://claude.ai/claude-code) installed
+- Working directory is a clone of the Accrue repo (the skill lives in `.claude/skills/accrue/`)
+- An API key for your chosen provider (OpenAI, Anthropic, or Google)
+
+## Quick Start
+
+Open Claude Code in a project that has Accrue installed, then invoke the skill:
+
+```
+> /accrue
+> I have 500 companies in accounts.csv and need to qualify them for ICP fit
+```
+
+The skill walks you through 6 phases:
+
+### Phase 1: Understand
+
+The skill reads your input data, checks columns and row count, and asks about your goal. If you're vague, it proposes an enrichment archetype (account qualification, lead research, company intelligence, etc.) and suggests fields to get the conversation moving.
+
+### Phase 2: Design Fields
+
+The most important phase. The skill proposes fields using Accrue's [7-key field spec](../guides/field-specifications.md) system and iterates with you:
+
+```
+Proposed fields for account qualification:
+
+| Field          | Type              | Notes                           |
+|----------------|-------------------|---------------------------------|
+| industry       | enum (10 + Other) | ICP segmentation                |
+| employee_count | str               | "500+" format                   |
+| icp_fit        | enum (3 levels)   | Strong Fit / Moderate / Weak    |
+| summary        | str               | One sentence, under 25 words    |
+
+Does this look right? Want to add, remove, or change anything?
+```
+
+The skill applies enrichment best practices: enums over free text, escape hatches for ambiguity, length constraints, boundary examples for classification, and null defaults where data may not exist.
+
+### Phase 3: Plan Pipeline
+
+The skill decides whether your enrichment needs one step or multiple, and recommends patterns:
+
+- **Single step** for straightforward enrichment
+- **Gate pattern** when cheap classification can filter rows before expensive research
+- **Chain pattern** when company research feeds into person research
+- **Fan-out** when independent enrichment types can run in parallel
+
+### Phase 4: Configure
+
+The skill picks settings with rationale:
+
+- **Model** -- `gpt-4.1-mini` for most enrichment, cheaper/bigger models when appropriate
+- **Grounding** -- Web search for time-sensitive or niche data, skipped for classification
+- **Workers** -- Based on row count and API tier
+- **Cache & checkpoint** -- Always recommended
+- **Batch mode** -- For large datasets where latency isn't critical
+
+It references model-specific prompt cookbooks (GPT-4.1 is hyper-literal; Claude prefers XML) and recommends `provider_kwargs` like Anthropic adaptive thinking when relevant.
+
+### Phase 5: Present & Confirm
+
+Before writing any code, the skill presents a structured summary:
+
+```
+## Enrichment Plan
+
+Input: accounts.csv (500 rows)
+Output: enriched_accounts.csv
+
+### Pipeline
+| Step             | Model         | Grounding | Condition              | Est. Cost |
+|------------------|---------------|-----------|------------------------|-----------|
+| classify         | gpt-4.1-nano  | No        | All rows               | ~$0.05    |
+| deep_research    | gpt-4.1-mini  | Web search| icp_fit == "Strong Fit"| ~$0.12    |
+
+### Configuration
+Workers: 10 | Cache: ON | Checkpoint: ON | Batch: No
+Est. total: ~$0.17 | Est. time: ~60s
+
+Any changes before I write the script?
+```
+
+### Phase 6: Hand Off
+
+The skill writes the script, suggests testing on 5-10 rows first, and gives you the run command:
+
+```bash
+python enrich.py
+```
+
+## What the Skill Knows
+
+The skill has access to reference material covering:
+
+- **[API surface](../../.claude/skills/accrue/references/api.md)** -- Every Pipeline, LLMStep, FunctionStep, and Config parameter
+- **[Prompt cookbook](../../.claude/skills/accrue/references/prompts.md)** -- Model-specific prompt guidance, enrichment templates, anti-patterns
+- **[Provider details](../../.claude/skills/accrue/references/providers.md)** -- Model comparison, cost tables, provider_kwargs, grounding behavior
+- **[Pipeline patterns](../../.claude/skills/accrue/references/patterns.md)** -- Gate, fan-out, chain, conditional, batch, incremental enrichment
+
+## Example Session
+
+```
+> /accrue
+
+> I have a CSV of 200 SaaS companies with name and website.
+> I need to figure out which ones are a good fit for our developer tools product.
+
+The skill will:
+1. Read your CSV, note it has 200 rows with company_name and website columns
+2. Propose an "account qualification" field set (industry, size, tech signals, ICP fit)
+3. Recommend a 2-step gate pattern: cheap classifier → detailed research on strong fits
+4. Pick gpt-4.1-mini with grounding for the research step
+5. Present a cost estimate (~$0.30) and configuration summary
+6. Write enrich.py with caching enabled, suggest testing on 10 rows first
+```
+
+## Tips
+
+- **Be specific about your goal.** "Qualify for ICP fit" gets better results than "enrich this data."
+- **Iterate on fields.** The first proposal is a starting point. Add domain-specific categories, adjust enums, tighten prompts.
+- **Test first.** The skill always suggests running on a small subset before the full dataset.
+- **Re-run cheaply.** With caching enabled, re-running after a crash or prompt tweak only processes new/changed rows.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -76,5 +76,6 @@ result = pipeline.run(data, config=EnrichmentConfig(enable_caching=True))
 
 ## Next steps
 
+- [Claude Code Skill](claude-code-skill.md) -- let `/accrue` build your pipeline interactively
 - [Core Concepts](core-concepts.md) -- understand the execution model
 - [Guides](../guides/) -- field specs, providers, conditional steps, batch API


### PR DESCRIPTION
## Summary
- Add `/accrue` skill for interactive pipeline building via Claude Code
- Add getting started guide for the skill
- Update README and quickstart with skill references
- Track `.claude/` directory in git

## Test plan
- [ ] Verify `/accrue` skill loads in Claude Code
- [ ] Verify docs render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)