### PR TITLE
fix: add version tag validation to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,15 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Verify version matches tag
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          PKG=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Tag v$TAG does not match pyproject.toml version $PKG"
+            exit 1
+          fi
+
       - name: Build package
         run: |
           pip install build


### PR DESCRIPTION
## Summary
- Adds a check that the git tag (e.g. `v1.1.0`) matches the version in `pyproject.toml` before publishing to PyPI
- Fails early with a clear error if they don't match

## Test plan
- [ ] Verify CI passes on this PR
- [ ] On next release, confirm the check runs before publish step

🤖 Generated with [Claude Code](https://claude.com/claude-code)