### PR TITLE
feat: add agentic SDLC scaffolding

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,81 @@
+---
+description: Cut a release — bump version, draft CHANGELOG, tag, push
+argument-hint: <new-version e.g. 1.3.0>
+---
+
+You are cutting release v$ARGUMENTS of accrue.
+
+The PyPI publish workflow (`.github/workflows/publish.yml`) **enforces that the git tag matches `pyproject.toml`'s version**. Get this right or publish fails.
+
+## 1. Sanity-check the request
+
+- Confirm we are on `main` and clean: `git status`, `git fetch`, `git log origin/main..HEAD` should be empty.
+- Read the current version: `grep '^version' pyproject.toml`.
+- Compare to the requested $ARGUMENTS — must be a strict semver bump (major / minor / patch).
+- If $ARGUMENTS is lower than or equal to the current version, **stop**.
+
+## 2. Gather what's changed
+
+```bash
+git log v<previous-version>..HEAD --oneline
+```
+
+Group commits by `feat:` / `fix:` / `docs:` / `refactor:` / `test:`. Drop trivial ones (formatting, comment-only).
+
+## 3. Draft the CHANGELOG entry
+
+If `CHANGELOG.md` exists, prepend a section. Otherwise create one. Format:
+
+```markdown
+## [$ARGUMENTS] - <YYYY-MM-DD>
+
+### Added
+- ...
+
+### Changed
+- ...
+
+### Fixed
+- ...
+```
+
+Only include sections that have entries.
+
+## 4. Bump version
+
+Edit `pyproject.toml`'s `version = "..."` to `$ARGUMENTS`. That is the only file the publish workflow checks — but if `accrue/__init__.py` exposes a `__version__`, bump it too.
+
+## 5. Verify
+
+```bash
+ruff check .
+ruff format --check .
+pytest -x -q
+python -m build
+```
+
+The build step catches packaging regressions before the tag goes out.
+
+## 6. Commit, tag, push
+
+```bash
+git add pyproject.toml CHANGELOG.md accrue/__init__.py
+git commit -m "feat: bump version to $ARGUMENTS"
+git tag v$ARGUMENTS
+git push origin main
+git push origin v$ARGUMENTS
+```
+
+Then create the GitHub Release — that's what triggers `publish.yml`:
+
+```bash
+gh release create v$ARGUMENTS --title "v$ARGUMENTS" --notes-from-tag
+```
+
+## 7. Watch it ship
+
+```bash
+gh run watch
+```
+
+If publish fails: the most likely cause is tag/version mismatch. Don't force-push — fix the version on `main`, retag, redo the release.

--- a/.claude/commands/ship-issue.md
+++ b/.claude/commands/ship-issue.md
@@ -1,0 +1,76 @@
+---
+description: Pick up a GitHub issue end-to-end — read it, plan, code, test, open a PR
+argument-hint: <issue-number>
+---
+
+You are shipping issue #$ARGUMENTS in the accrue repo.
+
+Follow the full lifecycle. Be conservative — small PRs beat big ones.
+
+## 1. Understand
+
+- `gh issue view $ARGUMENTS --comments` — read the issue and any discussion.
+- Check labels: `type:*` tells you scope, `component:*` tells you where.
+- If the issue is vague or missing repro, **stop and ask in a comment**. Don't guess.
+
+## 2. Plan
+
+- Read `CLAUDE.md` and `AGENTS.md` if you haven't this session.
+- Search the codebase for the relevant module under `accrue/`.
+- Sketch the diff in 3-5 bullets: which files, what changes, what tests.
+- Verify the plan respects the project's invariants:
+  - **Async-only steps.** No sync duplicates.
+  - **Step purity.** `dict[str, Any]` in/out, no pandas inside steps.
+  - **Internal fields use `__` prefix.**
+  - **Minimal deps.** No litellm, no langfuse.
+
+## 3. Branch
+
+```bash
+git checkout -b feature/issue-$ARGUMENTS-<short-slug>
+```
+
+Follow `feature/description` naming from `CLAUDE.md`.
+
+## 4. Code
+
+- Edit existing files where possible — don't create new ones unless the layout demands it.
+- Add or update tests under `tests/` for every behaviour change.
+- If you change architecture, update the relevant file in `docs/guides/`.
+
+## 5. Verify
+
+Run these and fix anything that fails before opening the PR:
+
+```bash
+ruff check .
+ruff format --check .
+pytest -x -q
+```
+
+## 6. Commit
+
+Use the format from `CLAUDE.md`:
+
+```
+<type>: <brief description>
+
+- Detail 1
+- Detail 2
+
+Closes #$ARGUMENTS
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+Types: `feat`, `fix`, `docs`, `refactor`, `test`.
+
+## 7. Open the PR
+
+Use `.github/pull_request_template.md`. PR title under 70 chars. Body covers Summary, Changes, Testing, Checklist. End with `Closes #$ARGUMENTS`.
+
+## When to bail
+
+- The issue is actually two issues — comment, ask the maintainer to split.
+- The change requires a design decision the issue doesn't resolve — comment with options, don't pick.
+- Tests fail in a way you don't understand — push the branch, open a draft PR, ask for input.

--- a/.claude/commands/sync-docs.md
+++ b/.claude/commands/sync-docs.md
@@ -1,0 +1,34 @@
+---
+description: Find drift between code and docs, propose patches
+---
+
+Audit the accrue repo for drift between `accrue/` (the source) and `docs/` + `README.md` (the docs).
+
+## What to check
+
+1. **Public API surface.** For each public class/function exported from `accrue/__init__.py`, confirm it appears in at least one of `README.md`, `docs/getting-started/`, or `docs/guides/`. Flag anything exported but undocumented.
+
+2. **Step types.** Every concrete step under `accrue/steps/` (e.g. `LLMStep`, `FunctionStep`) should have a corresponding section in `docs/guides/`. New step types without docs is the most common drift.
+
+3. **Provider docs.** `accrue/steps/providers/` should match `docs/guides/providers.md`. Check that every provider listed in code is in the doc, with the right install extra.
+
+4. **CLAUDE.md.** Specifically:
+   - The `Build Status` table — is it still accurate vs. closed/open issues?
+   - The `pip install` extras list — does it match `pyproject.toml`'s `[project.optional-dependencies]`?
+   - The Commands block — do the listed commands still work?
+
+5. **Examples drift.** Files under `examples/` should still run against current accrue. Don't run them, but read the imports — flag any that reference symbols that no longer exist.
+
+6. **`docs/guides/` cross-refs.** Anchor links between guides should resolve. Flag broken ones.
+
+## How to report
+
+For each piece of drift, output:
+
+- **Where**: file path and line, or section name
+- **What**: one sentence describing the mismatch
+- **Fix**: a proposed Edit (old/new strings) the user can apply
+
+Don't apply the patches yourself — surface them so the maintainer can review the batch.
+
+End with a one-line verdict: **"X drift findings, Y critical."** Critical = public API undocumented or example broken.

--- a/.claude/commands/triage-issues.md
+++ b/.claude/commands/triage-issues.md
@@ -1,0 +1,59 @@
+---
+description: Sweep open issues — apply labels, ask for repro on bugs, link near-duplicates
+---
+
+Run a triage pass on open issues in the accrue repo.
+
+## Step 1 — pull the queue
+
+```bash
+gh issue list --state open --limit 50 --json number,title,body,labels,createdAt,comments
+```
+
+## Step 2 — for each issue
+
+Apply this decision tree:
+
+1. **Already labelled with a `type:*` label?** Skip the type step.
+
+2. **Otherwise classify type** by reading title + body. Use exactly one of:
+   - `type:bug` — something is broken
+   - `type:task` — small concrete change
+   - `type:story` — user-facing feature
+   - `type:epic` — multi-issue effort
+   - `type:spike` — research / investigation
+
+3. **Component** (also exactly one):
+   - `component:core` — `accrue/core/`
+   - `component:steps` — `accrue/steps/`
+   - `component:pipeline` — `accrue/pipeline/`
+   - `component:data` — `accrue/data/`, schemas
+   - `component:testing` — `tests/`
+   - `component:docs` — `docs/`, `README.md`
+   - `component:infra` — CI, packaging, releases
+
+4. **Priority** if not set — read severity:
+   - `priority:critical` — blocks usage of the library
+   - `priority:high` — affects most users
+   - `priority:medium` — default
+   - `priority:low` — nice-to-have
+
+5. **Bugs without repro** — if `type:bug` and the body has no minimal example, post:
+   > Thanks for the report. Could you share a minimal pipeline that reproduces this — ideally a 5–10 line snippet plus the accrue version (`pip show accrue`)?
+
+   Add the `needs info` label.
+
+6. **Possible duplicates** — search closed and open issues for similar titles. If you find one with >70% confidence, comment linking it. Add `duplicate` label only if the maintainer should close — otherwise just link and leave the label off.
+
+## Step 3 — apply labels
+
+Use `gh issue edit <num> --add-label <label1>,<label2>,...`. Do not remove existing labels unless they're plainly wrong.
+
+## Step 4 — summarise
+
+End with a table:
+
+| # | Title | Labels added | Action |
+|---|---|---|---|
+
+Action is one of: `labelled`, `asked for repro`, `flagged duplicate`, `no change`.

--- a/.claude/hooks/lint-changed.sh
+++ b/.claude/hooks/lint-changed.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Lint the file Claude just edited. Runs after every Edit/Write, scoped
+# to the single file via the tool input passed on stdin. Exits 2 on
+# failure so Claude is told (via stderr) to fix it before continuing —
+# the "self-healing dev loop" pattern from Claude Code's hook docs.
+#
+# Wired in .claude/settings.json under hooks.PostToolUse.
+
+set -u
+
+# Skip gracefully if ruff isn't on PATH (e.g. venv not activated).
+# Silent no-op rather than blocking every turn for setup reasons.
+command -v ruff >/dev/null 2>&1 || exit 0
+
+file=$(python3 -c "import json,sys; print(json.load(sys.stdin).get('tool_input',{}).get('file_path',''))" 2>/dev/null || true)
+
+case "$file" in
+  *.py)
+    if ! ruff check "$file" 1>&2; then exit 2; fi
+    if ! ruff format --check "$file" 1>&2; then exit 2; fi
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/lint-changed.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/scripts/triage_issue.py
+++ b/.github/scripts/triage_issue.py
@@ -1,0 +1,98 @@
+"""Dogfood: triage a GitHub issue using accrue itself.
+
+Reads issue title + body from env (set by the calling workflow), runs a
+one-row accrue pipeline, prints the labels to apply on stdout. The
+workflow filters those against the repo's actual labels before applying,
+so missing labels fail soft.
+
+Usage (in CI):
+    ISSUE_TITLE="..." ISSUE_BODY="..." python .github/scripts/triage_issue.py
+
+Output (stdout, one line):
+    label1,label2,label3
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from accrue import LLMStep, Pipeline
+
+
+def main() -> int:
+    title = os.environ.get("ISSUE_TITLE", "").strip()
+    body = os.environ.get("ISSUE_BODY", "").strip()
+
+    if not title:
+        print("error: ISSUE_TITLE env var is empty", file=sys.stderr)
+        return 1
+
+    pipeline = Pipeline(
+        [
+            LLMStep(
+                "triage",
+                model="claude-haiku-4-5-20251001",
+                fields={
+                    "kind": {
+                        "prompt": (
+                            "Classify the issue. 'bug' if something is broken or "
+                            "behaves unexpectedly; 'enhancement' for a new feature "
+                            "or improvement; 'documentation' for doc-only work; "
+                            "'question' for a usage question with no defect."
+                        ),
+                        "enum": ["bug", "enhancement", "documentation", "question"],
+                    },
+                    "needs_info": {
+                        "prompt": (
+                            "True only if this is a bug report AND the issue lacks "
+                            "either a code snippet, error message, or version number. "
+                            "False for enhancements and documentation issues."
+                        ),
+                        "enum": ["true", "false"],
+                    },
+                    "good_first_issue": {
+                        "prompt": (
+                            "True if this is small, well-scoped, and a newcomer "
+                            "could reasonably tackle it without deep codebase "
+                            "knowledge. False otherwise."
+                        ),
+                        "enum": ["true", "false"],
+                    },
+                },
+            )
+        ]
+    )
+
+    result = pipeline.run(
+        [
+            {
+                "title": title,
+                "body": body or "(no body)",
+            }
+        ]
+    )
+
+    if not result.success_rate:
+        print("error: pipeline produced no rows", file=sys.stderr)
+        return 1
+
+    row = result.data.iloc[0].to_dict()
+    labels: list[str] = []
+
+    kind = row.get("kind", "").strip().lower()
+    if kind in {"bug", "enhancement", "documentation", "question"}:
+        labels.append(kind)
+
+    if str(row.get("needs_info", "")).lower() == "true":
+        labels.append("needs info")
+
+    if str(row.get("good_first_issue", "")).lower() == "true":
+        labels.append("good first issue")
+
+    print(",".join(labels))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/accrue-triage.yml
+++ b/.github/workflows/accrue-triage.yml
@@ -1,0 +1,73 @@
+name: Accrue triage (dogfood)
+
+# When an issue is opened, run an accrue pipeline against its title+body
+# to classify type / repro-needed / good-first-issue, then apply matching
+# labels via the gh CLI. This is the meta move: accrue maintains accrue.
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install accrue from source (with Anthropic provider)
+        run: pip install -e ".[anthropic]"
+
+      - name: Run triage pipeline
+        id: triage
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+        run: |
+          set -euo pipefail
+          LABELS=$(python .github/scripts/triage_issue.py)
+          echo "labels=$LABELS" >> "$GITHUB_OUTPUT"
+          echo "Suggested labels: $LABELS"
+
+      - name: Apply labels (filtered to existing)
+        if: steps.triage.outputs.labels != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          SUGGESTED: ${{ steps.triage.outputs.labels }}
+        run: |
+          set -euo pipefail
+          # Pull the repo's actual labels so we don't fail on a missing one.
+          mapfile -t REPO_LABELS < <(gh label list --limit 100 --json name --jq '.[].name')
+          IFS=',' read -ra WANT <<< "$SUGGESTED"
+          TO_APPLY=()
+          for label in "${WANT[@]}"; do
+            for existing in "${REPO_LABELS[@]}"; do
+              if [ "$label" = "$existing" ]; then
+                TO_APPLY+=("$label")
+                break
+              fi
+            done
+          done
+          if [ ${#TO_APPLY[@]} -gt 0 ]; then
+            JOINED=$(IFS=','; echo "${TO_APPLY[*]}")
+            gh issue edit "$ISSUE_NUMBER" --add-label "$JOINED"
+            echo "Applied: $JOINED"
+          else
+            echo "No suggested labels matched the repo's label set — skipping."
+          fi
+
+      - name: Comment if needs info
+        if: contains(steps.triage.outputs.labels, 'needs info')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" --body "Thanks for the report. Could you share a minimal pipeline that reproduces this — ideally a 5–10 line snippet plus the accrue version (\`pip show accrue\`)? This was auto-flagged by the dogfooded triage pipeline; a human will follow up."

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,62 @@
+name: Claude PR review
+
+# Auto-runs an agent review on every PR opened or updated against main.
+# Uses the action's inline-comment MCP tool so feedback lands as inline
+# review comments (not a wall of text). track_progress posts a single
+# tracking comment with visual progress as the review runs.
+#
+# Patterns from: https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+
+# Only review the latest push if the PR is updated mid-review.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          track_progress: true
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Review this pull request against the accrue codebase. Read
+            CLAUDE.md and AGENTS.md before reviewing.
+
+            Focus areas:
+            - Async-only step contract — no sync/async duplication
+            - Step purity — dict[str, Any] in/out, no pandas inside steps
+            - Internal-field naming — `__` prefix for inter-step data
+            - Provider boundaries — never add litellm/langfuse-style deps
+            - Tests — every behaviour change must touch tests/
+            - Doc drift — changes under accrue/ should update docs/guides/
+              if they shift architecture
+
+            Use `mcp__github_inline_comment__create_inline_comment`
+            (with `confirmed: true`) for line-level findings. Use
+            `gh pr comment` only for the final overall verdict.
+
+            Be terse. One sentence per finding, no preamble. End with a
+            verdict line: APPROVE / REQUEST CHANGES / COMMENT.
+          claude_args: |
+            --max-turns 30
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(git:*),Read,Grep,Glob"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,38 @@
+name: Claude (mention bot)
+
+# Lets contributors invoke an agent by commenting "@claude <ask>" on any
+# issue, PR, or review. v1 auto-detects mode from the event context, so
+# no `mode:` input is needed. The default trigger phrase is "@claude".
+#
+# Docs: https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # The action picks up CLAUDE.md, AGENTS.md, and .claude/commands/
+          # automatically when it spins up Claude Code in the runner.
+          claude_args: |
+            --max-turns 20

--- a/.github/workflows/weekly-maintenance.yml
+++ b/.github/workflows/weekly-maintenance.yml
@@ -1,0 +1,57 @@
+name: Weekly maintenance (scheduled)
+
+# Runs every Sunday at 02:00 UTC, plus on-demand via the Actions tab.
+# Sweeps: stale issues, doc/code drift, security advisories. Posts one
+# summary issue with findings.
+#
+# Pattern: https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md#scheduled-maintenance
+
+on:
+  schedule:
+    - cron: "0 2 * * 0"
+  workflow_dispatch:
+
+jobs:
+  maintenance:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+
+            Run weekly maintenance for the accrue repo. Read CLAUDE.md
+            and AGENTS.md before starting.
+
+            Tasks:
+            1. **Stale issues** — find open issues with no activity in
+               90+ days. List them with title and last-comment date.
+            2. **Doc/code drift** — pick three random public symbols
+               exported from accrue/__init__.py and confirm each appears
+               in either README.md, docs/getting-started/, or
+               docs/guides/. Flag any that don't.
+            3. **Version coherence** — confirm pyproject.toml's version
+               matches accrue/__init__.py's __version__. Flag mismatch.
+            4. **CHANGELOG presence** — if CHANGELOG.md doesn't exist,
+               note that it's missing.
+            5. **Examples sanity** — for each file under examples/,
+               read the imports and confirm every imported name still
+               exists in accrue's public API. Don't run them.
+
+            Post a single issue titled "Weekly maintenance — <date>"
+            summarising findings as a checklist. If everything is clean,
+            still post the issue with "All checks passed" so the run is
+            visible. Use `gh issue create`.
+          claude_args: |
+            --max-turns 25
+            --allowedTools "Read,Grep,Glob,Bash(gh issue:*),Bash(git:*),Bash(grep:*),Bash(find:*)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,82 @@
+# Agents in the Accrue repo
+
+Accrue is built using an agentic software development lifecycle modelled on Anthropic's own internal practice — colloquially called **"antfooding"** (Anthropic's technical staff are "ants"; antfooding is their version of dogfooding). Internally, ~70–80% of Anthropic engineers use Claude Code daily, and they use it to build Claude Code itself. This file describes the equivalent setup for the accrue repo: GitHub Actions wired to the official `claude-code-action`, repo-scoped slash commands, native Claude Code hooks, and one dogfooded pipeline that uses accrue itself to triage its own issues.
+
+The patterns here are taken from the official documentation, not guessed. Citations are at the bottom of this file.
+
+## TL;DR
+
+| What | Trigger | Where |
+|---|---|---|
+| `@claude` mention bot | Comment containing `@claude` on any issue, PR, or review | `.github/workflows/claude.yml` |
+| Auto PR review (inline) | Every non-draft PR opened/updated against `main` | `.github/workflows/claude-review.yml` |
+| Weekly maintenance | Sunday 02:00 UTC + manual `workflow_dispatch` | `.github/workflows/weekly-maintenance.yml` |
+| Accrue-triages-accrue | New issue opened | `.github/workflows/accrue-triage.yml` |
+| Lint-on-edit (local) | After every Edit/Write tool call by Claude Code | `.claude/settings.json` + `.claude/hooks/lint-changed.sh` |
+| `/ship-issue <num>` | Local Claude Code | `.claude/commands/ship-issue.md` |
+| `/release <version>` | Local Claude Code | `.claude/commands/release.md` |
+| `/sync-docs` | Local Claude Code | `.claude/commands/sync-docs.md` |
+| `/triage-issues` | Local Claude Code | `.claude/commands/triage-issues.md` |
+
+## Required secrets
+
+Add this in **Settings → Secrets and variables → Actions**:
+
+- `ANTHROPIC_API_KEY` — used by every workflow, including the dogfooded triage pipeline (which runs against Claude Haiku via accrue's Anthropic provider).
+
+Workflows fail closed without it — no agent runs, no PR comments, no surprise API spend.
+
+## Action version pin
+
+All workflows pin `anthropics/claude-code-action@v1`. Older examples on the web use `@beta` and the deprecated `direct_prompt` / `mode` / `custom_instructions` / `max_turns` / `model` inputs — those were collapsed into `prompt` and `claude_args` in v1.0. Don't copy `@beta` examples without translating.
+
+## How the pieces fit together
+
+### 1. Local development — slash commands + hooks
+
+When working in this repo with Claude Code, four project-scoped commands appear in the `/` menu. They encode accrue's specific workflow (pytest, ruff, version-tag matching, the `docs/guides/` layout) so you don't have to re-explain it every session.
+
+- **`/ship-issue <num>`** — read the issue, plan, code, test, lint, open a PR.
+- **`/release <version>`** — bump `pyproject.toml`, draft `CHANGELOG.md` from commits since the last tag, create the tag.
+- **`/sync-docs`** — diff `accrue/` against `docs/` + `README.md`, surface drift, propose patches.
+- **`/triage-issues`** — sweep open issues, apply labels, ask for repro on bug reports, link near-duplicates.
+
+`.claude/commands/` is where these live. It's still the supported location, though Claude Code is moving toward `.claude/skills/` as the unified home for commands+skills — both work today.
+
+`.claude/settings.json` adds a **PostToolUse hook** that runs `ruff check` + `ruff format --check` on every Python file Claude edits. If it fails, the hook exits 2, stderr is fed back to Claude, and Claude fixes it before stopping. This is the "self-healing dev loop" pattern — one of the most-used hook configurations in the docs.
+
+### 2. CI — agents on GitHub
+
+- **`@claude` mention bot.** Comment `@claude implement #9` on any issue or PR and the action picks it up. v1 auto-detects mode from event context — no `mode:` input needed.
+- **Auto PR review.** Runs on every non-draft PR. Uses `track_progress: true` for a visible tracking comment, and the `mcp__github_inline_comment__create_inline_comment` MCP tool so feedback lands as inline review comments rather than one wall of text. Tools are scoped via `claude_args: --allowedTools` for safety.
+- **Weekly maintenance.** Cron + `workflow_dispatch`. Sweeps stale issues, doc drift, version coherence, examples sanity. Posts one summary issue per run.
+
+### 3. Dogfooded triage — the meta move
+
+When an issue is opened, **`accrue-triage.yml`** runs `.github/scripts/triage_issue.py`, which builds a one-row Accrue pipeline over the issue's title and body and emits structured fields (`kind`, `needs_info`, `good_first_issue`). The workflow then filters those against the repo's actual labels and applies what matches.
+
+This is on purpose: the easiest way to dogfood a data-enrichment library is to use it on the data your repo already produces. The official action also offers a built-in issue-triage recipe (see solutions.md) — we're not using it for *this one workflow* because the dogfooding is the point. The two are complementary.
+
+## Adding a new agent or command
+
+1. **New slash command** — drop a markdown file in `.claude/commands/`. Filename is the command name. Frontmatter format: `description`, optional `argument-hint`. Body is the prompt.
+2. **New workflow** — add a YAML file under `.github/workflows/`. Always pin `@v1`. Use `prompt:` (not the deprecated `direct_prompt:`). Scope tools via `claude_args: --allowedTools "..."`.
+3. **New hook** — extend `.claude/settings.json`. Useful events for this repo: `PostToolUse` (file-level checks), `Stop` (turn-end checks), `PreToolUse` with `if: "Bash(rm *)"` (block destructive shell). Hook scripts go in `.claude/hooks/`.
+4. **Update this file** — every new entry-point gets a row in the TL;DR table above.
+
+## Costs and guardrails
+
+- All agentic workflows are gated: `@claude` requires explicit mention, review runs only on PRs, triage runs only on new issues, maintenance runs weekly. No infinite loops, no scheduled spend.
+- The dogfooded triage pipeline uses `claude-haiku-4-5-20251001` and processes one row per issue — pennies per run.
+- The PR review action uses `--allowedTools` to constrain which Bash commands and MCP tools it can call. Don't widen this without a reason.
+- To temporarily disable a workflow, comment out its `on:` block — don't delete the file.
+
+## Sources (verified, not guessed)
+
+- **`claude-code-action` repo** — [`github.com/anthropics/claude-code-action`](https://github.com/anthropics/claude-code-action). Authoritative for inputs, version tags, MCP tool names.
+- **Solutions guide** — [`solutions.md`](https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md). PR review, issue triage, scheduled maintenance, doc-sync recipes are lifted from here.
+- **Usage guide** — [`usage.md`](https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md). v0→v1 migration table, full input reference.
+- **Claude Code GitHub Actions docs** — [`code.claude.com/docs/en/github-actions`](https://code.claude.com/docs/en/github-actions).
+- **Hooks reference** — [`code.claude.com/docs/en/hooks`](https://code.claude.com/docs/en/hooks). Authoritative for `.claude/settings.json` schema, event names, exit-code semantics.
+- **"Antfooding" practice** — described publicly by the Claude Code team on the [Every podcast](https://every.to/podcast/how-to-use-claude-code-like-the-people-who-built-it). Source of the 70–80% internal-usage figure.
+- **Awesome Claude Code** — [`github.com/hesreallyhim/awesome-claude-code`](https://github.com/hesreallyhim/awesome-claude-code). Curated real-world commands/hooks/skills for cross-reference.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Agentic SDLC scaffolding: GitHub Actions for `@claude` mention, PR review, weekly maintenance, and dogfooded issue triage. Repo-scoped slash commands under `.claude/commands/`. Local `PostToolUse` hook for ruff-on-edit. See `AGENTS.md`.
+
+### Fixed
+- `accrue/__init__.py` `__version__` was out of sync with `pyproject.toml`.
+
+## [1.2.0] - 2026-04-25
+
+### Added
+- `http_client` support for provider clients.
+- Pipeline result summary printed at end of `run()`.
+
+### Fixed
+- Internal field (`__`-prefixed) handling in step output filtering.
+
+### Changed
+- Updated `/accrue` skill documentation.
+
+## [1.1.0] - 2026-04-15
+
+### Added
+- Auto-loading of `.env` files via `python-dotenv` on import.
+- Publish workflow now validates that the git tag matches `pyproject.toml`'s version before pushing to PyPI.
+
+## [1.0.0] - 2026-04
+
+Initial public release.

--- a/accrue/__init__.py
+++ b/accrue/__init__.py
@@ -39,7 +39,7 @@ from .steps import FunctionStep, LLMStep, Step, StepContext, StepResult
 from .steps.providers.base import BatchCapableLLMClient, BatchRequest, BatchResult
 from .utils.web_search import web_search
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 __author__ = "Accrue Team"
 
 __all__ = [


### PR DESCRIPTION
## Summary

Adds the agentic software development lifecycle to the accrue repo — modelled on Anthropic's own internal practice (antfooding) where Claude Code is used to build Claude Code. One `ANTHROPIC_API_KEY` secret powers everything.

| What | Trigger | Where |
|---|---|---|
| `@claude` mention bot | `@claude <ask>` on issue/PR/review | `.github/workflows/claude.yml` |
| Auto PR review (inline) | Every non-draft PR vs `main` | `.github/workflows/claude-review.yml` |
| Weekly maintenance | Sun 02:00 UTC + dispatch | `.github/workflows/weekly-maintenance.yml` |
| Accrue-triages-accrue | New issue opened | `.github/workflows/accrue-triage.yml` |
| Lint-on-edit (local) | After every Claude Edit/Write | `.claude/settings.json` + `.claude/hooks/lint-changed.sh` |
| `/ship-issue <num>` | Local Claude Code | `.claude/commands/ship-issue.md` |
| `/release <version>` | Local Claude Code | `.claude/commands/release.md` |
| `/sync-docs` | Local Claude Code | `.claude/commands/sync-docs.md` |
| `/triage-issues` | Local Claude Code | `.claude/commands/triage-issues.md` |

## Changes

- **GitHub Actions** — four workflows pinned to `anthropics/claude-code-action@v1`. Auto-detect mode from event context (no deprecated `mode:` / `direct_prompt:` / `custom_instructions:`). PR review uses `track_progress: true` and the `mcp__github_inline_comment__create_inline_comment` MCP tool for inline feedback. Tools tightly scoped via `claude_args: --allowedTools "..."`.
- **Slash commands** — encode accrue-specific workflow (pytest, ruff, version-tag matching from publish.yml, `docs/guides/` layout) so future agents and contributors don't re-explain it.
- **PostToolUse hook** — runs `ruff check` + `ruff format --check` on the single file Claude just edited. Exits 2 on failure to feed the self-healing loop. No-ops silently if ruff isn't on PATH.
- **Dogfooded triage** — `accrue-triage.yml` runs `.github/scripts/triage_issue.py`, which builds a one-row Accrue pipeline against Claude Haiku to classify new issues, then applies labels filtered against the repo's actual label set.
- **AGENTS.md** — contributor guide with verified citations to the official `claude-code-action` solutions guide, hooks reference, and v0→v1 migration notes.
- **CHANGELOG.md** — seeded.
- **Fix: `accrue/__init__.py:42`** — sync `__version__` from `1.1.0` to `1.2.0` to match `pyproject.toml`.

## Heads-up on smoke testing

GitHub Actions only fire from `pull_request` events if the workflow already exists on the **base branch**. So this PR will not auto-review itself — that's expected. After merge:

- The next PR will trigger `claude-review.yml`
- The next issue will trigger `accrue-triage.yml`
- `weekly-maintenance.yml` can be fired immediately via the Actions tab → workflow_dispatch

## Required secret

- `ANTHROPIC_API_KEY` — already added (per the conversation that produced this PR)

## Test plan

- [ ] Manual review of workflow YAML and slash commands
- [ ] Merge
- [ ] Open a tiny throwaway PR (e.g. doc typo) → confirm `claude-review.yml` posts inline comments
- [ ] Open a throwaway issue → confirm `accrue-triage.yml` labels it
- [ ] Trigger `weekly-maintenance.yml` via workflow_dispatch → confirm it posts a summary issue

## Sources

- [anthropics/claude-code-action solutions.md](https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md)
- [anthropics/claude-code-action usage.md](https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md)
- [Claude Code hooks reference](https://code.claude.com/docs/en/hooks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)