### PR TITLE
fix: triage script — result.data is a list, not a DataFrame

### DIFF
--- a/.github/scripts/triage_issue.py
+++ b/.github/scripts/triage_issue.py
@@ -91,7 +91,9 @@ def main() -> int:
         )
         return 1
 
-    row = result.data.iloc[0].to_dict()
+    # Pipeline.run() preserves input type: we pass list[dict], we get
+    # list[dict] back. (See PipelineResult.data type annotation.)
+    row = result.data[0]
     labels: list[str] = []
 
     kind = row.get("kind", "").strip().lower()


### PR DESCRIPTION
## Summary

Third and final triage fix. Smoke-test issue #24 surfaced a runtime crash in the script after PR #22 merged:

\`\`\`
AttributeError: 'list' object has no attribute 'iloc'
  at .github/scripts/triage_issue.py:94 — result.data.iloc[0].to_dict()
\`\`\`

\`PipelineResult.data\` is typed \`pd.DataFrame | list[dict[str, Any]]\` (see [\`pipeline.py:79\`](https://github.com/matt-house-e/accrue/blob/main/accrue/pipeline/pipeline.py#L79)) and *preserves the input type*. The script passes a \`list[dict]\` (one row), so the result is also a \`list[dict]\` — \`.iloc\` doesn't exist.

## Fix

\`result.data.iloc[0].to_dict()\` → \`result.data[0]\` (with comment).

## Verification path

The error logging added in PR #22 worked exactly as designed: instead of the silent \`error: pipeline produced no rows\`, this run posted the actual traceback to stderr. Without that, this would have been another silent failure cycle.

## Test plan

- [ ] CI passes
- [ ] Auto-review approves
- [ ] After merge: open one more throwaway issue → confirm labels actually land this time
- [ ] Close test issues #23 and #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)