### PR TITLE
fix: strip markdown fences in LLMStep.parse_response (closes #7)

### DIFF
--- a/accrue/steps/llm.py
+++ b/accrue/steps/llm.py
@@ -448,8 +448,8 @@ class LLMStep:
             pydantic.ValidationError: If the parsed JSON fails schema
                 validation.
         """
-        content = _strip_markdown_fences(response.content)
-        parsed = json.loads(content)
+        content = response.content
+        parsed = json.loads(_strip_markdown_fences(content))
 
         # Extract __ internal fields before Pydantic validation (which
         # rejects them due to extra="forbid").  They bypass schema

--- a/accrue/steps/llm.py
+++ b/accrue/steps/llm.py
@@ -34,9 +34,27 @@ except ImportError:
 
 logger = get_logger(__name__)
 
+
 # ---------------------------------------------------------------------------
 # Refusal detection for default enforcement
 # ---------------------------------------------------------------------------
+def _strip_markdown_fences(content: str) -> str:
+    """Strip surrounding markdown code fences if present.
+
+    Some Claude models (notably Haiku with grounding tools) wrap JSON
+    in ``` ... ``` fences when not constrained by structured outputs.
+    Safe to call on unfenced content — returns it unchanged.
+    """
+    s = content.strip()
+    if not s.startswith("```"):
+        return content
+    lines = s.split("\n")
+    lines = lines[1:]
+    if lines and lines[-1].strip() == "```":
+        lines = lines[:-1]
+    return "\n".join(lines)
+
+
 REFUSAL_PATTERNS = frozenset(
     {
         "unable to determine",
@@ -430,7 +448,7 @@ class LLMStep:
             pydantic.ValidationError: If the parsed JSON fails schema
                 validation.
         """
-        content = response.content
+        content = _strip_markdown_fences(response.content)
         parsed = json.loads(content)
 
         # Extract __ internal fields before Pydantic validation (which

--- a/tests/test_batch_foundation.py
+++ b/tests/test_batch_foundation.py
@@ -304,6 +304,48 @@ class TestParseResponse:
         with pytest.raises(json.JSONDecodeError):
             step.parse_response(response)
 
+    def test_strips_markdown_fences_with_json_hint(self):
+        """Claude Haiku with grounding wraps JSON in ```json...``` fences."""
+        step = LLMStep(
+            name="s",
+            fields={"market_size": "Estimate TAM"},
+            client=AsyncMock(spec=["complete"]),
+        )
+        response = _mock_llm_response('```json\n{"market_size": "$5B"}\n```')
+        result = step.parse_response(response)
+        assert result.values == {"market_size": "$5B"}
+
+    def test_strips_markdown_fences_without_hint(self):
+        step = LLMStep(
+            name="s",
+            fields={"market_size": "Estimate TAM"},
+            client=AsyncMock(spec=["complete"]),
+        )
+        response = _mock_llm_response('```\n{"market_size": "$5B"}\n```')
+        result = step.parse_response(response)
+        assert result.values == {"market_size": "$5B"}
+
+    def test_strips_fences_with_surrounding_whitespace(self):
+        step = LLMStep(
+            name="s",
+            fields={"market_size": "Estimate TAM"},
+            client=AsyncMock(spec=["complete"]),
+        )
+        response = _mock_llm_response('\n  ```json\n{"market_size": "$5B"}\n```  \n')
+        result = step.parse_response(response)
+        assert result.values == {"market_size": "$5B"}
+
+    def test_unfenced_json_unchanged(self):
+        """Regression: bare JSON must still parse (no fence-handling regression)."""
+        step = LLMStep(
+            name="s",
+            fields={"market_size": "Estimate TAM"},
+            client=AsyncMock(spec=["complete"]),
+        )
+        response = _mock_llm_response('{"market_size": "$5B"}')
+        result = step.parse_response(response)
+        assert result.values == {"market_size": "$5B"}
+
     def test_default_enforcement(self):
         step = LLMStep(
             name="s",


### PR DESCRIPTION
## Summary

Fixes #7. Claude models (notably Haiku) wrap JSON output in markdown code fences when not constrained by structured outputs — and Anthropic's grounding tools disable the structured-output constraint, so this happens on every grounded run. \`json.loads\` then fails with \`Expecting value: line 1 column 1 (char 0)\` and every row errors.

## Changes

### \`accrue/steps/llm.py\`

- New \`_strip_markdown_fences(content: str) -> str\` helper. Strips a leading triple-backtick fence (with optional language hint) and a trailing fence if present. No-op on unfenced content — safe to call unconditionally.
- \`LLMStep.parse_response\` now calls it before \`json.loads\`.

### \`tests/test_batch_foundation.py\`

Four new tests under \`TestParseResponse\`:

- \`test_strips_markdown_fences_with_json_hint\` — \`\`\`json...\`\`\` form
- \`test_strips_markdown_fences_without_hint\` — plain \`\`\` form
- \`test_strips_fences_with_surrounding_whitespace\` — whitespace tolerance
- \`test_unfenced_json_unchanged\` — regression guard

## Why at \`parse_response\` (LLMStep) and not \`_extract_text\` (Anthropic)

Defensive against any provider that emits fenced output. If/when other providers regress similarly, no second fix is needed. The cost is one \`startswith\` check per row, and the strip path is a no-op for OpenAI's clean structured-output responses.

## Verification

- \`uvx ruff check\` + \`uvx ruff format --check\` — clean
- \`pytest --ignore=tests/integration\` — **487 passed** (was 483 before this PR)

## Test plan

- [ ] CI passes
- [ ] Auto-review approves
- [ ] After merge: re-run the repro from #7 to confirm grounded Anthropic pipelines now succeed
- [ ] Close #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)