### PR TITLE
feat: default enable_caching to True (closes #8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Agentic SDLC scaffolding: GitHub Actions for `@claude` mention, PR review, weekly maintenance, and dogfooded issue triage. Repo-scoped slash commands under `.claude/commands/`. Local `PostToolUse` hook for ruff-on-edit. See `AGENTS.md`.
 
+### Changed
+- **`EnrichmentConfig.enable_caching` now defaults to `True`** (was `False`). Re-runs of unchanged inputs no longer re-pay the API cost. Opt out with `EnrichmentConfig(enable_caching=False)` for one-off runs.
+
 ### Fixed
+- `LLMStep.parse_response` now strips markdown code fences before `json.loads`. Fixes parse failures with Claude Haiku + grounding tools, where the structured-output constraint is disabled and the model wraps JSON in ` ``` ` fences. (#7)
 - `accrue/__init__.py` `__version__` was out of sync with `pyproject.toml`.
 
 ## [1.2.0] - 2026-04-25

--- a/accrue/core/config.py
+++ b/accrue/core/config.py
@@ -71,8 +71,14 @@ class EnrichmentConfig:
     """Automatically resume from checkpoint on re-run."""
 
     # === Caching ===
-    enable_caching: bool = False
-    """Enable input-hash cache to skip redundant API calls."""
+    enable_caching: bool = True
+    """Enable input-hash cache to skip redundant API calls.
+
+    Defaults to True since re-running a pipeline against unchanged
+    inputs should not re-pay the API cost. Opt out with
+    ``EnrichmentConfig(enable_caching=False)`` for one-off runs or
+    when you want a guaranteed fresh result.
+    """
 
     cache_ttl: int = 3600
     """Cache time-to-live in seconds."""

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -71,7 +71,7 @@ Avoid redundant API calls on re-runs. Cached results are stored in a local SQLit
 ```python
 from accrue import EnrichmentConfig
 
-result = pipeline.run(data, config=EnrichmentConfig(enable_caching=True))
+result = pipeline.run(data)  # caching is on by default
 ```
 
 ## Next steps

--- a/docs/guides/caching.md
+++ b/docs/guides/caching.md
@@ -13,8 +13,8 @@ pipeline = Pipeline([
     LLMStep("analyze", fields={"summary": "Summarize the company"}, model="gpt-4.1-mini"),
 ])
 
-config = EnrichmentConfig(enable_caching=True)
-result = pipeline.run(data, config=config)
+# Caching is on by default — no config flag needed.
+result = pipeline.run(data)
 ```
 
 Re-running the same pipeline with the same data skips cached rows entirely. No API calls are made for rows that already have results.
@@ -77,7 +77,7 @@ FunctionStep("stock_price", fn=get_price, fields=["price"], cache=False)
 FunctionStep("score", fn=score_v2, fields=["score"], cache_version="v2")
 ```
 
-A step with `cache=False` always makes the API call (or runs the function), even when `enable_caching=True` in the config. A step with `cache=True` only caches if the global config also has `enable_caching=True`.
+A step with `cache=False` always makes the API call (or runs the function), even when caching is enabled at the config level. A step with `cache=True` only caches when the global config has `enable_caching=True` (the default).
 
 ### Clear cache
 
@@ -164,7 +164,7 @@ EnrichmentConfig.for_batch()        # Batch API settings with caching and checkp
 
 ## Gotchas
 
-- Caching is off by default (`enable_caching=False`). You must opt in via config. The `cache=True` default on individual steps only means "this step is cacheable"; it does not enable the cache system.
+- Caching is on by default (`enable_caching=True`). To run without caching — typically for one-off runs or when you need a guaranteed-fresh result — pass `EnrichmentConfig(enable_caching=False)`. The `cache=True` default on individual steps only means "this step is cacheable"; it does not by itself enable or disable the cache system.
 - `cache_version` is a FunctionStep feature. LLMStep cache keys are derived from prompts, model, temperature, and field specs, so they auto-invalidate when those change. There is no `cache_version` on LLMStep.
 - Cache TTL is checked lazily on read. Expired entries are not proactively deleted. Call `CacheManager.cleanup_expired()` if you need to reclaim disk space.
 - The cache directory (`.accrue/`) should be gitignored. Add `.accrue/` to your `.gitignore`.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -5,7 +5,7 @@
 ```python
 from accrue import Pipeline, EnrichmentConfig
 
-config = EnrichmentConfig(max_workers=20, enable_caching=True)
+config = EnrichmentConfig(max_workers=20)
 result = pipeline.run(data, config=config)
 ```
 
@@ -22,7 +22,7 @@ result = pipeline.run(data, config=config)
 | `on_error` | `"continue"` | `"continue"` collects errors; `"raise"` fails fast |
 | `log_level` | `"INFO"` | Logging level |
 | `enable_progress_bar` | `True` | Show tqdm progress bar |
-| `enable_caching` | `False` | SQLite input-hash cache |
+| `enable_caching` | `True` | SQLite input-hash cache (set `False` for one-off runs) |
 | `cache_ttl` | `3600` | Cache TTL in seconds |
 | `cache_dir` | `".accrue"` | Directory for `cache.db` |
 | `enable_checkpointing` | `False` | Step-level crash recovery |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -346,7 +346,7 @@ class EnrichmentConfig:
     checkpoint_interval: int = 0
 
     # Caching
-    enable_caching: bool = False
+    enable_caching: bool = True
     cache_ttl: int = 3600
     cache_dir: str = ".accrue"
 
@@ -371,7 +371,7 @@ class EnrichmentConfig:
 | `checkpoint_dir` | `None` | Directory for checkpoint files. `None` uses a temp directory. |
 | `auto_resume` | `True` | Automatically resume from checkpoint on re-run. |
 | `checkpoint_interval` | `0` | Save partial step progress every N rows. `0` disables. |
-| `enable_caching` | `False` | Enable input-hash SQLite cache to skip redundant API calls. |
+| `enable_caching` | `True` | Enable input-hash SQLite cache to skip redundant API calls. Set `False` for one-off runs or when you need a guaranteed-fresh result. |
 | `cache_ttl` | `3600` | Cache time-to-live in seconds. |
 | `cache_dir` | `".accrue"` | Directory for `cache.db`. |
 | `batch_poll_interval` | `60.0` | Seconds between batch job status checks. |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,22 @@
 """Shared pytest fixtures for accrue tests.
 
-Auto-isolates the on-disk cache. ``EnrichmentConfig.cache_dir`` defaults
-to the relative path ``.accrue``, so without isolation every test that
-runs a pipeline with the default config writes to the project's
-``.accrue/cache.db`` and leaks state into subsequent tests. Now that
-``enable_caching`` defaults to True, that leak is no longer dormant.
+Auto-isolates the on-disk cache.
 
-Tests that explicitly want to test caching across runs can still pass
+``EnrichmentConfig.cache_dir`` defaults to the relative string ``.accrue``.
+With ``enable_caching`` now defaulting to True, every test that
+constructs a default config writes to ``./.accrue/cache.db`` — and that
+file persists across tests, causing cache hits to leak state.
+
+We can't cleanly patch the default itself: ``@dataclass`` binds field
+defaults into ``__init__.__defaults__`` at class creation, so a
+``monkeypatch.setattr`` on ``__dataclass_fields__["cache_dir"].default``
+is a no-op for fresh ``EnrichmentConfig()`` calls. Instead we change
+the cwd per test so the relative path resolves to a fresh location.
+This is broader scope than ideal, but it's reliable, doesn't touch
+library code, and accrue's tests don't currently read fixtures by
+relative path (they use absolute paths or ``tmp_path``).
+
+Tests that need a specific cache location can still pass
 ``cache_dir=str(tmp_path / "x")`` to override.
 """
 
@@ -17,7 +27,4 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def _isolate_cache_dir(tmp_path, monkeypatch):
-    """Run every test from a fresh cwd so the relative ``.accrue/`` cache
-    is per-test rather than shared across the whole suite. monkeypatch
-    restores the cwd after each test."""
     monkeypatch.chdir(tmp_path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Shared pytest fixtures for accrue tests.
+
+Auto-isolates the on-disk cache. ``EnrichmentConfig.cache_dir`` defaults
+to the relative path ``.accrue``, so without isolation every test that
+runs a pipeline with the default config writes to the project's
+``.accrue/cache.db`` and leaks state into subsequent tests. Now that
+``enable_caching`` defaults to True, that leak is no longer dormant.
+
+Tests that explicitly want to test caching across runs can still pass
+``cache_dir=str(tmp_path / "x")`` to override.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_cache_dir(tmp_path, monkeypatch):
+    """Run every test from a fresh cwd so the relative ``.accrue/`` cache
+    is per-test rather than shared across the whole suite. monkeypatch
+    restores the cwd after each test."""
+    monkeypatch.chdir(tmp_path)

--- a/tests/test_batch_foundation.py
+++ b/tests/test_batch_foundation.py
@@ -185,6 +185,22 @@ class TestConfigBatchFields:
         assert config.max_retries == 5
 
 
+# -- EnrichmentConfig caching defaults --------------------------------------
+
+
+class TestConfigCachingDefaults:
+    def test_enable_caching_defaults_to_true(self):
+        """Caching is on by default — re-running a pipeline against
+        unchanged inputs should not re-pay the API cost. Opt out
+        explicitly with EnrichmentConfig(enable_caching=False)."""
+        config = EnrichmentConfig()
+        assert config.enable_caching is True
+
+    def test_enable_caching_can_be_disabled(self):
+        config = EnrichmentConfig(enable_caching=False)
+        assert config.enable_caching is False
+
+
 # -- LLMStep batch param ----------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Closes #8. \`EnrichmentConfig.enable_caching\` now defaults to \`True\`. Re-running a pipeline against unchanged inputs no longer re-pays the API cost. Opt out with \`EnrichmentConfig(enable_caching=False)\`.

## Changes

### \`accrue/core/config.py\`

- \`enable_caching: bool = False\` → \`True\`
- Expanded docstring describing the opt-out path

### \`tests/conftest.py\` *(new file)*

Autouse fixture that \`chdir\`s each test to a fresh \`tmp_path\`. Without it, the new default would cause 14 existing tests to leak cache state between runs (relative \`.accrue/cache.db\` is shared across the cwd).

This is a real test-isolation gap that the new default exposed — fixing the underlying issue once is cleaner than touching 14 tests to either pass \`enable_caching=False\` or scope \`cache_dir\` per-test. monkeypatch restores the cwd after each test.

### \`tests/test_batch_foundation.py\`

\`TestConfigCachingDefaults\` (2 tests):
- \`test_enable_caching_defaults_to_true\` — pins the new contract
- \`test_enable_caching_can_be_disabled\` — confirms opt-out still works

## Verification

- \`uvx ruff check\` + \`uvx ruff format --check\` — clean
- \`pytest --ignore=tests/integration\` — **489 passed** (was 487, +2 from the new regression tests; the conftest fixture makes the existing 14 affected tests pass without modification)

## Test plan

- [ ] CI passes
- [ ] Auto-review approves
- [ ] After merge: existing pipelines re-run without modification continue to work; only new \`EnrichmentConfig()\` instances pick up caching by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)