### PR TITLE
feat: auto-detect LLM provider from model name (closes #23)

### DIFF
--- a/.github/scripts/triage_issue.py
+++ b/.github/scripts/triage_issue.py
@@ -18,7 +18,6 @@ import os
 import sys
 
 from accrue import LLMStep, Pipeline
-from accrue.providers import AnthropicClient
 
 
 def main() -> int:
@@ -29,15 +28,11 @@ def main() -> int:
         print("error: ISSUE_TITLE env var is empty", file=sys.stderr)
         return 1
 
-    # accrue's LLMStep defaults to OpenAIClient regardless of model name
-    # (see accrue/steps/llm.py::_resolve_client). We pass AnthropicClient
-    # explicitly so this works against ANTHROPIC_API_KEY only.
     pipeline = Pipeline(
         [
             LLMStep(
                 "triage",
                 model="claude-haiku-4-5-20251001",
-                client=AnthropicClient(),
                 fields={
                     "kind": {
                         "prompt": (

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - **`EnrichmentConfig.enable_caching` now defaults to `True`** (was `False`). Re-runs of unchanged inputs no longer re-pay the API cost. Opt out with `EnrichmentConfig(enable_caching=False)` for one-off runs.
+- **`LLMStep` auto-detects provider from model name.** `claude-*` → `AnthropicClient`, `gemini-*` → `GoogleClient`, anything else (or any model with `base_url` set) → `OpenAIClient`. Previously every Claude/Gemini user had to pass `client=AnthropicClient()` or `client=GoogleClient()` explicitly. Explicit `client=` still wins. (#23)
 
 ### Fixed
 - `LLMStep.parse_response` now strips markdown code fences before `json.loads`. Fixes parse failures with Claude Haiku + grounding tools, where the structured-output constraint is disabled and the model wraps JSON in ` ``` ` fences. (#7)

--- a/accrue/steps/llm.py
+++ b/accrue/steps/llm.py
@@ -262,8 +262,38 @@ class LLMStep:
     # -- client ----------------------------------------------------------
 
     def _resolve_client(self) -> LLMClient:
-        """Lazily create or return the LLMClient."""
-        if self._client is None:
+        """Lazily create or return the LLMClient.
+
+        Picks the provider by model-name prefix when no explicit ``client``
+        was passed:
+
+          * ``claude-*``  → ``AnthropicClient``  (requires ``accrue[anthropic]``)
+          * ``gemini-*``  → ``GoogleClient``    (requires ``accrue[google]``)
+          * everything else, or any model when ``base_url`` is set → ``OpenAIClient``
+
+        ``base_url`` always implies an OpenAI-compatible endpoint
+        (Ollama, Groq, etc.) regardless of model name; users running
+        Claude or Gemini through a non-OpenAI gateway should pass
+        ``client=`` explicitly.
+        """
+        if self._client is not None:
+            return self._client
+
+        if self.base_url is None and self.model.startswith("claude-"):
+            if _AnthropicClient is None:
+                raise ImportError(
+                    f"Model '{self.model}' requires the Anthropic provider. "
+                    "Install with: pip install accrue[anthropic]"
+                )
+            self._client = _AnthropicClient(api_key=self.api_key)
+        elif self.base_url is None and self.model.startswith("gemini-"):
+            if _GoogleClient is None:
+                raise ImportError(
+                    f"Model '{self.model}' requires the Google provider. "
+                    "Install with: pip install accrue[google]"
+                )
+            self._client = _GoogleClient(api_key=self.api_key)
+        else:
             self._client = OpenAIClient(
                 api_key=self.api_key,
                 base_url=self.base_url,

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -59,11 +59,13 @@ pipeline = Pipeline([
 ])
 ```
 
-The provider is auto-detected from the `gemini-` model prefix. **Install:** `pip install accrue[google]`. **Auth:** set `GOOGLE_API_KEY`. Override with `client=GoogleClient(...)` for non-default options.
+The provider is auto-detected from the `gemini-` model prefix. No explicit `client=` import needed.
 
 **Install:** `pip install accrue[google]`
 
-**Auth:** Set `GOOGLE_API_KEY` or pass `api_key=` to `GoogleClient()`.
+**Auth:** Set `GOOGLE_API_KEY` (or pass `api_key=` to `LLMStep`).
+
+**Custom client (optional):** Pass `client=GoogleClient(...)` to override auto-detection with non-default options.
 
 **Grounding:** Supports native Google Search grounding via the `grounding` parameter on LLMStep.
 

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -24,21 +24,23 @@ OpenAI uses the Responses API natively, which enables web search and structured 
 ## Anthropic
 
 ```python
-from accrue.providers import AnthropicClient
 from accrue import Pipeline, LLMStep
 
 pipeline = Pipeline([
     LLMStep("analyze",
         fields={"summary": "Summarize the company"},
         model="claude-sonnet-4-5-20250929",
-        client=AnthropicClient(),
     ),
 ])
 ```
 
+The provider is auto-detected from the `claude-` model prefix. No explicit `client=` import needed.
+
 **Install:** `pip install accrue[anthropic]`
 
-**Auth:** Set `ANTHROPIC_API_KEY` or pass `api_key=` to `AnthropicClient()`.
+**Auth:** Set `ANTHROPIC_API_KEY` (or pass `api_key=` to `LLMStep`).
+
+**Custom client (optional):** For non-default Anthropic SDK options pass `client=AnthropicClient(...)` explicitly — overrides auto-detection.
 
 **Prompt caching:** Accrue automatically adds `cache_control: {"type": "ephemeral"}` to system messages. On repeated calls with the same system prompt, Anthropic caches the prompt tokens for roughly 90% savings on system prompt input costs. No configuration required.
 
@@ -47,17 +49,17 @@ pipeline = Pipeline([
 ## Google
 
 ```python
-from accrue.providers import GoogleClient
 from accrue import Pipeline, LLMStep
 
 pipeline = Pipeline([
     LLMStep("analyze",
         fields={"summary": "Summarize the company"},
         model="gemini-2.5-flash",
-        client=GoogleClient(),
     ),
 ])
 ```
+
+The provider is auto-detected from the `gemini-` model prefix. **Install:** `pip install accrue[google]`. **Auth:** set `GOOGLE_API_KEY`. Override with `client=GoogleClient(...)` for non-default options.
 
 **Install:** `pip install accrue[google]`
 

--- a/tests/test_llm_step.py
+++ b/tests/test_llm_step.py
@@ -168,6 +168,87 @@ class TestLLMStepClient:
         assert c1 is c2
 
 
+# -- provider auto-detection from model name ---------------------------------
+
+
+class TestProviderAutoDetect:
+    """Auto-pick the provider client from the model-name prefix when no
+    explicit ``client`` is passed. Closes #23."""
+
+    @patch("openai.AsyncOpenAI")
+    def test_gpt_prefix_uses_openai(self, mock_cls):
+        from accrue.steps.providers.openai import OpenAIClient
+
+        step = LLMStep(name="s", fields=["f"], model="gpt-4.1-mini", api_key="k")
+        assert isinstance(step._resolve_client(), OpenAIClient)
+
+    def test_claude_prefix_uses_anthropic(self):
+        from accrue.steps.providers.anthropic import AnthropicClient
+
+        step = LLMStep(
+            name="s",
+            fields=["f"],
+            model="claude-haiku-4-5-20251001",
+            api_key="k",
+        )
+        assert isinstance(step._resolve_client(), AnthropicClient)
+
+    def test_gemini_prefix_uses_google(self):
+        from accrue.steps.providers.google import GoogleClient
+
+        step = LLMStep(name="s", fields=["f"], model="gemini-1.5-pro", api_key="k")
+        assert isinstance(step._resolve_client(), GoogleClient)
+
+    @patch("openai.AsyncOpenAI")
+    def test_unknown_prefix_falls_back_to_openai(self, mock_cls):
+        """o1-/o3- and any other unknown prefix go to OpenAI (back-compat)."""
+        from accrue.steps.providers.openai import OpenAIClient
+
+        step = LLMStep(name="s", fields=["f"], model="o3-mini", api_key="k")
+        assert isinstance(step._resolve_client(), OpenAIClient)
+
+    @patch("openai.AsyncOpenAI")
+    def test_base_url_overrides_model_prefix(self, mock_cls):
+        """base_url means OpenAI-compatible endpoint regardless of model name."""
+        from accrue.steps.providers.openai import OpenAIClient
+
+        step = LLMStep(
+            name="s",
+            fields=["f"],
+            model="claude-haiku-4-5-20251001",
+            base_url="http://localhost:8080/v1",
+            api_key="k",
+        )
+        assert isinstance(step._resolve_client(), OpenAIClient)
+
+    def test_explicit_client_overrides_auto_detection(self):
+        mock_client = AsyncMock()
+        step = LLMStep(
+            name="s",
+            fields=["f"],
+            model="claude-haiku-4-5-20251001",
+            client=mock_client,
+        )
+        assert step._resolve_client() is mock_client
+
+    def test_claude_prefix_without_extra_raises_clear_error(self, monkeypatch):
+        monkeypatch.setattr("accrue.steps.llm._AnthropicClient", None)
+        step = LLMStep(
+            name="s",
+            fields=["f"],
+            model="claude-haiku-4-5-20251001",
+            api_key="k",
+        )
+        with pytest.raises(ImportError, match="pip install accrue\\[anthropic\\]"):
+            step._resolve_client()
+
+    def test_gemini_prefix_without_extra_raises_clear_error(self, monkeypatch):
+        monkeypatch.setattr("accrue.steps.llm._GoogleClient", None)
+        step = LLMStep(name="s", fields=["f"], model="gemini-1.5-pro", api_key="k")
+        with pytest.raises(ImportError, match="pip install accrue\\[google\\]"):
+            step._resolve_client()
+
+
 # -- system message building --------------------------------------------
 
 


### PR DESCRIPTION
## What it does

\`LLMStep\` now picks the provider client from the model-name prefix automatically. \`claude-*\` → Anthropic, \`gemini-*\` → Google, anything else (or any model with \`base_url\` set) → OpenAI.

## Value

Removes a real footgun. Before this PR, \`LLMStep(model=\"claude-haiku-4-5-...\")\` silently sent the request to OpenAI's API and every row failed at the LLM call. Users had to know to import \`AnthropicClient\` and pass \`client=AnthropicClient()\` — which contradicted the README's \"zero config\" pitch. Now the model name alone is sufficient.

Bonus: lets us delete the \`client=AnthropicClient()\` workaround that the dogfooded triage script (#22) had to ship around exactly this bug.

## Before / After

\`\`\`python
# Before — silent failure
LLMStep(\"triage\", model=\"claude-haiku-4-5-20251001\", fields={...})

# Workaround everyone had to discover
from accrue.providers import AnthropicClient
LLMStep(\"triage\", model=\"claude-haiku-4-5-20251001\",
        client=AnthropicClient(), fields={...})

# After — just works
LLMStep(\"triage\", model=\"claude-haiku-4-5-20251001\", fields={...})
\`\`\`

## How it decides

| Condition | Client |
|---|---|
| \`base_url\` set | \`OpenAIClient\` (OpenAI-compatible endpoints — Ollama, Groq, etc.) |
| Model starts \`claude-\` | \`AnthropicClient\` (requires \`accrue[anthropic]\`) |
| Model starts \`gemini-\` | \`GoogleClient\` (requires \`accrue[google]\`) |
| Anything else | \`OpenAIClient\` (\`gpt-*\`, \`o1-\`, \`o3-\`, custom names) |
| Explicit \`client=\` | always wins |

Missing-extra cases raise a clear \`ImportError\` pointing at the install command instead of failing at the API layer.

## Changes

- \`accrue/steps/llm.py:_resolve_client\` — auto-detection logic + expanded docstring
- \`.github/scripts/triage_issue.py\` — drops the \`AnthropicClient()\` workaround
- \`tests/test_llm_step.py\` — new \`TestProviderAutoDetect\` class, 8 tests covering every branch
- \`docs/guides/providers.md\` — Anthropic and Google sections lead with auto-detected form
- \`CHANGELOG.md\` — notes the change under Unreleased

## Verification

- \`pytest --ignore=tests/integration\` — **497 passed** (was 489, +8 new tests)
- \`ruff check\` + \`ruff format --check\` — clean

## Test plan

- [ ] CI passes
- [ ] Auto-review approves (now on Sonnet 4.6 from PR #29 — first real PR through the cheaper model)
- [ ] After merge: re-run the triage workflow on a fresh issue to confirm it still works without the explicit client

🤖 Generated with [Claude Code](https://claude.com/claude-code)