### PR TITLE
docs: drop client= boilerplate now that provider auto-detects + /ship-issue overview step

### DIFF
--- a/.claude/commands/ship-issue.md
+++ b/.claude/commands/ship-issue.md
@@ -7,6 +7,18 @@ You are shipping issue #$ARGUMENTS in the accrue repo.
 
 Follow the full lifecycle. Be conservative — small PRs beat big ones.
 
+## 0. Overview first
+
+Before any planning, branching, or code, post a brief feature overview to the user so they can grok the change instantly without reading the PR body or diff. Keep it under 8 lines:
+
+```
+**What it does:** <one sentence>
+**Value:** <one or two sentences — who benefits, what gets simpler>
+**Before / After:** <minimal code snippet showing the API change>
+```
+
+Then continue.
+
 ## 1. Understand
 
 - `gh issue view $ARGUMENTS --comments` — read the issue and any discussion.

--- a/docs/cookbook/company-enrichment.md
+++ b/docs/cookbook/company-enrichment.md
@@ -228,16 +228,15 @@ print(result.data[["company", "market_position", "growth_score"]])
 
 ## Using a Different Provider
 
-Swap in Anthropic or Google by passing a `client` argument:
+Swap in Anthropic or Google by changing the `model` name — the provider is auto-detected from the prefix:
 
 ```python
-from accrue.providers import AnthropicClient
-
 LLMStep(
     "classify",
     fields={...},
     depends_on=["research"],
-    client=AnthropicClient(),
-    model="claude-sonnet-4-20250514",
+    model="claude-sonnet-4-20250514",  # claude-* → Anthropic
 )
 ```
+
+Requires the matching extra: `pip install accrue[anthropic]` for Claude, `pip install accrue[google]` for Gemini. Pass `client=AnthropicClient(...)` or `client=GoogleClient(...)` explicitly only when you need to customize the underlying SDK.

--- a/docs/guides/batch-api.md
+++ b/docs/guides/batch-api.md
@@ -71,17 +71,17 @@ print(usage.cache_hit_rate)  # Float between 0.0 and 1.0
 
 ```python
 from accrue import Pipeline, LLMStep
-from accrue.steps.providers.anthropic import AnthropicClient
 
 pipeline = Pipeline([
     LLMStep("analyze",
         fields={"market_size": "Estimate TAM"},
-        client=AnthropicClient(),
         model="claude-sonnet-4-20250514",
         batch=True,
     ),
 ])
 ```
+
+The Anthropic provider is auto-detected from the `claude-` model prefix. Requires `pip install accrue[anthropic]`.
 
 The Anthropic adapter uses the Message Batches API. System messages automatically get `cache_control` annotations for prompt caching savings.
 

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -145,7 +145,6 @@ The `provider_kwargs` parameter is an escape hatch for provider-specific feature
 LLMStep("deep_analysis",
     fields={"analysis": "Detailed strategic analysis"},
     model="claude-sonnet-4-5-20250929",
-    client=AnthropicClient(),
     provider_kwargs={"thinking": {"type": "adaptive"}},
 )
 


### PR DESCRIPTION
## Summary

Two loose ends from PR #30, bundled.

**1. Doc cleanup** — three guides still showed \`client=AnthropicClient()\` boilerplate that #23's auto-detection now makes redundant. The reviewer flagged \`docs/guides/providers.md:148\` twice on PR #30 as a copy-paste failure (the snippet used \`AnthropicClient\` without showing the import). Same pattern in two more files.

| File | Was | Now |
|---|---|---|
| \`docs/guides/providers.md\` (provider_kwargs example) | \`client=AnthropicClient()\` line + missing import | \`model=claude-...\` only — auto-detected |
| \`docs/guides/batch-api.md\` (Anthropic batch example) | Explicit import + \`client=AnthropicClient()\` | \`model=claude-...\` only |
| \`docs/cookbook/company-enrichment.md\` (\"Using a Different Provider\") | Required \`client=\` import | \`model=claude-...\` only; explicit \`client=\` framed as customize-only |

**2. \`/ship-issue\` overview step** — adds a "0. Overview first" prefix to the slash command. When you (or the \`@claude\` mention bot) invoke \`/ship-issue <num>\`, the agent now leads with a brief feature overview block before planning or code:

\`\`\`
**What it does:** ...
**Value:** ...
**Before / After:** ...
\`\`\`

Encodes the convention you set this session — readers can grok any change in 8 lines without diving into the PR body. Saved as a feedback memory too.

## Verification

No code changes — pure docs + slash command. Tests will pass unchanged. Auto-review on Sonnet 4.6 should be quick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)