### PR TITLE
fix: remove import-time side effects, bump __version__ to 1.2.0

### DIFF
--- a/accrue/__init__.py
+++ b/accrue/__init__.py
@@ -4,14 +4,9 @@ A programmatic enrichment engine built on composable, column-oriented
 pipeline steps with Pydantic validation, checkpointing, and async concurrency.
 """
 
-from dotenv import load_dotenv
+import logging as _logging
 
-load_dotenv()
-
-# Set up default logging when package is imported
-from .utils.logger import setup_logging
-
-setup_logging(level="WARNING", format_type="console", include_timestamp=False)
+_logging.getLogger("accrue").addHandler(_logging.NullHandler())
 
 # Public API
 from .core import (
@@ -37,9 +32,10 @@ from .schemas.field_spec import FieldSpec
 from .schemas.grounding import GroundingConfig
 from .steps import FunctionStep, LLMStep, Step, StepContext, StepResult
 from .steps.providers.base import BatchCapableLLMClient, BatchRequest, BatchResult
+from .utils.logger import setup_logging
 from .utils.web_search import web_search
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 __author__ = "Accrue Team"
 
 __all__ = [
@@ -64,6 +60,7 @@ __all__ = [
     "FieldSpec",
     "GroundingConfig",
     # Utilities
+    "setup_logging",
     "web_search",
     # Batch API
     "BatchCapableLLMClient",

--- a/accrue/utils/logger.py
+++ b/accrue/utils/logger.py
@@ -117,10 +117,6 @@ def setup_logging(
     root_logger.setLevel(numeric_level)
     root_logger.addHandler(handler)
 
-    # Quiet down noisy third-party loggers
-    logging.getLogger("urllib3").setLevel(logging.WARNING)
-    logging.getLogger("requests").setLevel(logging.WARNING)
-
 
 def get_logger(name: str) -> logging.Logger:
     """


### PR DESCRIPTION
## Summary
- Drops `load_dotenv()` call on import — library code must not rewrite `os.environ`
- Drops `setup_logging()` call on import — replaces with `NullHandler` on the `accrue` logger per Python logging best practices
- Removes urllib3/requests global logger muting from `setup_logging()` — that's host-application state
- Bumps `__version__` to `1.2.0` to match `pyproject.toml`; keeps `setup_logging` as an opt-in re-export in `__all__`

## Why
Library code must not mutate process-level state on import. Closes #38.

## Test plan
- [x] pytest -x -q passes (483 passed)
- [x] ruff check clean
- [ ] CI green