### PR TITLE
fix: enum-aware refusal detection — keep valid enum values

### DIFF
--- a/accrue/steps/llm.py
+++ b/accrue/steps/llm.py
@@ -388,14 +388,39 @@ class LLMStep:
     # -- default enforcement ---------------------------------------------
 
     def _apply_defaults(self, values: dict[str, Any]) -> dict[str, Any]:
-        """Replace refusal values with field defaults where configured."""
+        """Replace refusal values with field defaults where configured.
+
+        Skip the override when the field declares an ``enum`` and the value
+        (case-insensitive, stripped) is a member of that enum — the model's
+        output is then a legitimate categorical answer, not a refusal.
+        """
         for field_name, spec in self._field_specs.items():
             if field_name not in values:
                 continue
             if "default" not in spec.model_fields_set:
                 continue
-            if _is_refusal(values[field_name]):
-                values[field_name] = spec.default
+            if not _is_refusal(values[field_name]):
+                continue
+            # Value looks like a refusal — check whether it is a valid enum member
+            if spec.enum is not None and isinstance(values[field_name], str):
+                normalized = values[field_name].strip().lower()
+                enum_lower = {v.lower() for v in spec.enum}
+                if normalized in enum_lower:
+                    logger.debug(
+                        "LLMStep._apply_defaults: field '%s' value %r matches "
+                        "REFUSAL_PATTERNS but is a declared enum member — keeping.",
+                        field_name,
+                        values[field_name],
+                    )
+                    continue
+            logger.debug(
+                "LLMStep._apply_defaults: field '%s' value %r matches "
+                "REFUSAL_PATTERNS — replacing with default %r.",
+                field_name,
+                values[field_name],
+                spec.default,
+            )
+            values[field_name] = spec.default
         return values
 
     # -- batch helpers ---------------------------------------------------

--- a/tests/test_llm_step.py
+++ b/tests/test_llm_step.py
@@ -481,6 +481,82 @@ class TestDefaultEnforcement:
         result = await step.run(_make_ctx())
         assert result.values["f1"] is None
 
+    @pytest.mark.asyncio
+    async def test_enum_member_refusal_pattern_kept(self):
+        """A refusal-pattern value that is a declared enum member is NOT replaced."""
+        # Arrange
+        resp = _mock_llm_response(json.dumps({"status": "unknown"}))
+        mock_client = _make_mock_client(resp)
+        step = LLMStep(
+            name="llm",
+            fields={
+                "status": {"prompt": "classify", "enum": ["known", "unknown"], "default": "REVIEW"},
+            },
+            client=mock_client,
+        )
+        # Act
+        result = await step.run(_make_ctx())
+        # Assert — "unknown" is a valid enum value; default must NOT be applied
+        assert result.values["status"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_enum_non_member_refusal_pattern_replaced(self):
+        """A refusal-pattern value NOT in the enum still falls back to default."""
+        # Arrange
+        resp = _mock_llm_response(json.dumps({"status": "n/a"}))
+        mock_client = _make_mock_client(resp)
+        step = LLMStep(
+            name="llm",
+            fields={
+                "status": {"prompt": "classify", "enum": ["known", "unknown"], "default": "REVIEW"},
+            },
+            client=mock_client,
+        )
+        # Act
+        result = await step.run(_make_ctx())
+        # Assert — "n/a" is not in the enum, so the default applies
+        assert result.values["status"] == "REVIEW"
+
+    @pytest.mark.asyncio
+    async def test_enum_member_match_is_case_insensitive(self):
+        """Enum membership check is case-insensitive: "unknown" matches "Unknown"."""
+        # Arrange — enum uses title-case, model returns lowercase
+        resp = _mock_llm_response(json.dumps({"status": "unknown"}))
+        mock_client = _make_mock_client(resp)
+        step = LLMStep(
+            name="llm",
+            fields={
+                "status": {
+                    "prompt": "classify",
+                    "enum": ["Known", "Unknown"],
+                    "default": "REVIEW",
+                },
+            },
+            client=mock_client,
+        )
+        # Act
+        result = await step.run(_make_ctx())
+        # Assert — case-insensitive match keeps the model output unchanged
+        assert result.values["status"] == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_no_enum_refusal_still_replaced(self):
+        """Regression: field with no enum + refusal output keeps the original behaviour."""
+        # Arrange
+        resp = _mock_llm_response(json.dumps({"score": "unknown"}))
+        mock_client = _make_mock_client(resp)
+        step = LLMStep(
+            name="llm",
+            fields={
+                "score": {"prompt": "rate 1-10", "default": "N/A"},
+            },
+            client=mock_client,
+        )
+        # Act
+        result = await step.run(_make_ctx())
+        # Assert — no enum defined, so the default is applied as before
+        assert result.values["score"] == "N/A"
+
 
 # -- retries on validation/parse error -----------------------------------
 


### PR DESCRIPTION
## Summary

- `_apply_defaults` in `accrue/steps/llm.py` now skips the refusal-override when the field declares an `enum` and the matched value (case-insensitive, stripped) is a member of that enum
- Adds `logger.debug(...)` whenever a refusal-override is considered, whether or not it fires, so users can audit via DEBUG logging
- 4 focused regression tests added to `tests/test_llm_step.py`

## Why (closes #45)

`REFUSAL_PATTERNS` includes words like `"unknown"` and `"n/a"`. A user defining `FieldSpec(enum=["known","unknown"], default="REVIEW")` would silently receive `"REVIEW"` whenever the model legitimately returned `"unknown"` as a categorical answer. The fix treats a refusal-pattern value as intentional when it is a declared enum member.

## Test plan

- [ ] `enum=["known","unknown"]` with `default="REVIEW"` and model output `"unknown"` — asserts value kept as `"unknown"`, not replaced by default
- [ ] Same field, model output `"n/a"` (not in enum) — asserts fallback to `"REVIEW"`
- [ ] Case-insensitivity: `enum=["Known","Unknown"]`, output `"unknown"` (lowercase) — asserts kept (case-insensitive match)
- [ ] Field with no enum + refusal output — asserts default applied (existing behaviour unchanged)