### PR TITLE
fix: thread-safe SQLite cache (check_same_thread, busy_timeout, write lock, TTL cleanup)

### DIFF
--- a/accrue/core/cache.py
+++ b/accrue/core/cache.py
@@ -9,9 +9,14 @@ from __future__ import annotations
 import hashlib
 import json
 import sqlite3
+import threading
 import time
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
+
+# How often to re-run TTL cleanup on init (seconds).
+_CLEANUP_INTERVAL = 86400  # 1 day
 
 
 class CacheManager:
@@ -31,6 +36,7 @@ class CacheManager:
         self._cache_dir = Path(cache_dir)
         self._ttl = ttl
         self._conn: sqlite3.Connection | None = None
+        self._write_lock = threading.Lock()
 
     def _ensure_connection(self) -> sqlite3.Connection:
         if self._conn is not None:
@@ -39,8 +45,9 @@ class CacheManager:
         self._cache_dir.mkdir(parents=True, exist_ok=True)
         db_path = self._cache_dir / "cache.db"
 
-        self._conn = sqlite3.connect(str(db_path))
+        self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
         self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA busy_timeout=5000")
         self._conn.execute("PRAGMA synchronous=NORMAL")
         self._conn.execute("PRAGMA cache_size=-8000")  # 8 MB
 
@@ -55,8 +62,47 @@ class CacheManager:
         """)
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_step ON cache(step_name)")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_expires ON cache(expires_at)")
+
+        # Meta table for tracking lazy cleanup
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS cache_meta (
+                key   TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            )
+        """)
         self._conn.commit()
+
+        # Lazy TTL cleanup: run once per process, gated by a meta marker
+        self._maybe_cleanup_on_init()
+
         return self._conn
+
+    def _maybe_cleanup_on_init(self) -> None:
+        """Run cleanup_expired() once per process if it hasn't run recently."""
+        assert self._conn is not None
+        row = self._conn.execute(
+            "SELECT value FROM cache_meta WHERE key = 'last_cleanup'"
+        ).fetchone()
+
+        should_clean = True
+        if row is not None:
+            try:
+                last_ts = datetime.fromisoformat(row[0])
+                age = (datetime.now(timezone.utc) - last_ts).total_seconds()
+                if age < _CLEANUP_INTERVAL:
+                    should_clean = False
+            except ValueError:
+                pass  # Malformed timestamp — clean anyway
+
+        if should_clean:
+            self.cleanup_expired()
+            now_iso = datetime.now(timezone.utc).isoformat()
+            with self._write_lock:
+                self._conn.execute(
+                    "INSERT OR REPLACE INTO cache_meta (key, value) VALUES ('last_cleanup', ?)",
+                    (now_iso,),
+                )
+                self._conn.commit()
 
     def get(self, key: str) -> dict | None:
         """Look up a cached value by key. Returns None on miss or expiry."""
@@ -68,8 +114,9 @@ class CacheManager:
 
         value_json, expires_at = row
         if expires_at is not None and time.time() > expires_at:
-            conn.execute("DELETE FROM cache WHERE key = ?", (key,))
-            conn.commit()
+            with self._write_lock:
+                conn.execute("DELETE FROM cache WHERE key = ?", (key,))
+                conn.commit()
             return None
 
         return json.loads(value_json)
@@ -80,35 +127,39 @@ class CacheManager:
         now = time.time()
         expires_at = (now + self._ttl) if self._ttl > 0 else None
 
-        conn.execute(
-            "INSERT OR REPLACE INTO cache (key, step_name, value, created_at, expires_at) "
-            "VALUES (?, ?, ?, ?, ?)",
-            (key, step_name, json.dumps(value, default=str), now, expires_at),
-        )
-        conn.commit()
+        with self._write_lock:
+            conn.execute(
+                "INSERT OR REPLACE INTO cache (key, step_name, value, created_at, expires_at) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (key, step_name, json.dumps(value, default=str), now, expires_at),
+            )
+            conn.commit()
 
     def delete_step(self, step_name: str) -> int:
         """Delete all cache entries for a step. Returns count deleted."""
         conn = self._ensure_connection()
-        cursor = conn.execute("DELETE FROM cache WHERE step_name = ?", (step_name,))
-        conn.commit()
+        with self._write_lock:
+            cursor = conn.execute("DELETE FROM cache WHERE step_name = ?", (step_name,))
+            conn.commit()
         return cursor.rowcount
 
     def delete_all(self) -> int:
         """Delete all cache entries. Returns count deleted."""
         conn = self._ensure_connection()
-        cursor = conn.execute("DELETE FROM cache")
-        conn.commit()
+        with self._write_lock:
+            cursor = conn.execute("DELETE FROM cache")
+            conn.commit()
         return cursor.rowcount
 
     def cleanup_expired(self) -> int:
         """Remove all expired entries. Returns count deleted."""
         conn = self._ensure_connection()
-        cursor = conn.execute(
-            "DELETE FROM cache WHERE expires_at IS NOT NULL AND expires_at < ?",
-            (time.time(),),
-        )
-        conn.commit()
+        with self._write_lock:
+            cursor = conn.execute(
+                "DELETE FROM cache WHERE expires_at IS NOT NULL AND expires_at < ?",
+                (time.time(),),
+            )
+            conn.commit()
         return cursor.rowcount
 
     def close(self) -> None:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import concurrent.futures
+import sqlite3
+import threading
+import time
 from unittest.mock import patch
 
 from accrue.core.cache import (
@@ -117,6 +121,98 @@ class TestCacheManager:
         mgr.set("k1", "step_a", {"v": 1})
         mgr.close()
         mgr.close()  # Should not raise
+
+    # ------------------------------------------------------------------
+    # Concurrency / thread-safety tests
+    # ------------------------------------------------------------------
+
+    def test_concurrent_set_from_two_threads(self, tmp_path):
+        """Two threads sharing a CacheManager can both call .set() safely."""
+        mgr = CacheManager(cache_dir=str(tmp_path), ttl=3600)
+        errors: list[Exception] = []
+
+        def worker(key: str) -> None:
+            try:
+                mgr.set(key, "step_a", {"key": key})
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            futs = [pool.submit(worker, f"key_{i}") for i in range(2)]
+            concurrent.futures.wait(futs)
+
+        assert errors == [], f"Unexpected errors: {errors}"
+        assert mgr.get("key_0") == {"key": "key_0"}
+        assert mgr.get("key_1") == {"key": "key_1"}
+        mgr.close()
+
+    def test_cross_thread_get_no_programming_error(self, tmp_path):
+        """Connection opened in thread A, .get() from thread B — no ProgrammingError."""
+        mgr = CacheManager(cache_dir=str(tmp_path), ttl=3600)
+        # Force connection open on the main thread
+        mgr.set("tk", "step_a", {"v": 99})
+
+        result: list = []
+        errors: list[Exception] = []
+
+        def reader() -> None:
+            try:
+                result.append(mgr.get("tk"))
+            except sqlite3.ProgrammingError as exc:
+                errors.append(exc)
+
+        t = threading.Thread(target=reader)
+        t.start()
+        t.join()
+
+        assert errors == [], f"ProgrammingError raised: {errors}"
+        assert result == [{"v": 99}]
+        mgr.close()
+
+    def test_busy_timeout_pragma_is_set(self, tmp_path):
+        """PRAGMA busy_timeout is 5000 ms."""
+        mgr = CacheManager(cache_dir=str(tmp_path), ttl=3600)
+        conn = mgr._ensure_connection()
+        value = conn.execute("PRAGMA busy_timeout").fetchone()[0]
+        assert value == 5000
+        mgr.close()
+
+    def test_ttl_cleanup_on_init_removes_expired_rows(self, tmp_path):
+        """Expired rows inserted directly are removed when a fresh CacheManager is opened."""
+        # Seed a db with an already-expired row via a raw connection
+        db_path = tmp_path / "cache.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS cache (
+                key        TEXT PRIMARY KEY,
+                step_name  TEXT NOT NULL,
+                value      TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                expires_at REAL
+            )
+        """)
+        # expires_at in the past
+        conn.execute(
+            "INSERT INTO cache (key, step_name, value, created_at, expires_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("expired_key", "step_x", '{"v":1}', time.time() - 7200, time.time() - 3600),
+        )
+        conn.commit()
+        conn.close()
+
+        # Fresh CacheManager should trigger cleanup on first connection
+        mgr = CacheManager(cache_dir=str(tmp_path), ttl=3600)
+        # Trigger _ensure_connection via a benign .get()
+        mgr.get("unrelated_key")
+
+        # Verify expired row is gone via direct DB read
+        raw = sqlite3.connect(str(db_path))
+        row = raw.execute("SELECT key FROM cache WHERE key = 'expired_key'").fetchone()
+        raw.close()
+
+        assert row is None, "Expired row should have been cleaned up on init"
+        mgr.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Pass `check_same_thread=False` to `sqlite3.connect` so async workers on different threads can share one connection without `ProgrammingError`
- Add `PRAGMA busy_timeout=5000` so concurrent writers wait up to 5 s instead of immediately raising `OperationalError: database is locked`
- Add a `threading.Lock` (`self._write_lock`) wrapping all write paths (`set`, `delete_step`, `delete_all`, `cleanup_expired`, and the lazy delete in `get`)
- Run `cleanup_expired()` lazily on first connection, gated by a `cache_meta` table row so it only re-runs after 1 day

## Test plan

- [x] `test_concurrent_set_from_two_threads` — two `ThreadPoolExecutor` workers share one `CacheManager` and both `.set()` — no errors, both keys land
- [x] `test_cross_thread_get_no_programming_error` — connection opened on main thread, `.get()` from a second thread — no `ProgrammingError`
- [x] `test_busy_timeout_pragma_is_set` — asserts `PRAGMA busy_timeout` returns 5000
- [x] `test_ttl_cleanup_on_init_removes_expired_rows` — inserts an already-expired row directly in SQLite, fresh `CacheManager` cleans it up on first connection
- [x] 509 tests pass, ruff clean

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)