### PR TITLE
fix(pipeline): drain tasks + flush partial checkpoint on cancellation (#42)

### DIFF
--- a/accrue/pipeline/pipeline.py
+++ b/accrue/pipeline/pipeline.py
@@ -638,7 +638,14 @@ class Pipeline:
                     )
                     for step_name in steps_to_run
                 ]
-                step_results_list = await asyncio.gather(*level_coros)
+                gathered = await asyncio.gather(*level_coros, return_exceptions=True)
+
+                # Surface the first exception (after siblings have been awaited)
+                first_exc = next((r for r in gathered if isinstance(r, BaseException)), None)
+                if first_exc is not None:
+                    raise first_exc
+
+                step_results_list = gathered
 
                 for step_name, (step_errors, usage, elapsed_s) in zip(
                     steps_to_run, step_results_list
@@ -818,65 +825,79 @@ class Pipeline:
 
             tasks = [asyncio.create_task(tracked_row(i)) for i in range(num_rows)]
             completed_count = 0
-            for coro in asyncio.as_completed(tasks):
-                idx, result_or_none, exc = await coro
+            try:
+                for coro in asyncio.as_completed(tasks):
+                    idx, result_or_none, exc = await coro
 
-                if exc is not None:
-                    row_error = RowError(
-                        row_index=idx,
-                        step_name=step.name,
-                        error=exc,
-                    )
-                    errors.append(row_error)
-                    results[idx] = {f: None for f in step.fields}
-                    logger.warning(
-                        "Row %d failed in step '%s': %s",
-                        idx,
-                        step.name,
-                        exc,
-                    )
-
-                    # Fire on_row_complete for error
-                    await _fire_hook(
-                        hooks.on_row_complete,
-                        RowCompleteEvent(
-                            step_name=step.name,
+                    if exc is not None:
+                        row_error = RowError(
                             row_index=idx,
-                            values={f: None for f in step.fields},
+                            step_name=step.name,
                             error=exc,
-                            from_cache=False,
-                            skipped=row_was_skipped[idx],
-                        ),
-                    )
+                        )
+                        errors.append(row_error)
+                        results[idx] = {f: None for f in step.fields}
+                        logger.warning(
+                            "Row %d failed in step '%s': %s",
+                            idx,
+                            step.name,
+                            exc,
+                        )
 
-                    if on_error == "raise":
-                        step_values[step.name] = results
-                        # Cancel remaining tasks
-                        for t in tasks:
-                            t.cancel()
-                        raise exc
-                else:
-                    results[idx] = result_or_none.values
-                    if result_or_none.usage:
-                        usage_list.append(result_or_none.usage)
+                        # Fire on_row_complete for error
+                        await _fire_hook(
+                            hooks.on_row_complete,
+                            RowCompleteEvent(
+                                step_name=step.name,
+                                row_index=idx,
+                                values={f: None for f in step.fields},
+                                error=exc,
+                                from_cache=False,
+                                skipped=row_was_skipped[idx],
+                            ),
+                        )
 
-                    # Fire on_row_complete for success
-                    await _fire_hook(
-                        hooks.on_row_complete,
-                        RowCompleteEvent(
-                            step_name=step.name,
-                            row_index=idx,
-                            values=result_or_none.values,
-                            error=None,
-                            from_cache=row_from_cache[idx],
-                            skipped=row_was_skipped[idx],
-                        ),
-                    )
+                        if on_error == "raise":
+                            step_values[step.name] = results
+                            # Cancel and drain remaining tasks before raising
+                            for t in tasks:
+                                if not t.done():
+                                    t.cancel()
+                            await asyncio.gather(*tasks, return_exceptions=True)
+                            raise exc
+                    else:
+                        results[idx] = result_or_none.values
+                        if result_or_none.usage:
+                            usage_list.append(result_or_none.usage)
 
-                completed_count += 1
-                row_bar.update(1)
-                if completed_count % checkpoint_interval == 0:
+                        # Fire on_row_complete for success
+                        await _fire_hook(
+                            hooks.on_row_complete,
+                            RowCompleteEvent(
+                                step_name=step.name,
+                                row_index=idx,
+                                values=result_or_none.values,
+                                error=None,
+                                from_cache=row_from_cache[idx],
+                                skipped=row_was_skipped[idx],
+                            ),
+                        )
+
+                    completed_count += 1
+                    row_bar.update(1)
+                    if completed_count % checkpoint_interval == 0:
+                        on_partial_checkpoint(step.name, results, completed_count)
+            except (asyncio.CancelledError, KeyboardInterrupt):
+                # Drain all in-flight tasks so they don't race teardown
+                for t in tasks:
+                    if not t.done():
+                        t.cancel()
+                await asyncio.gather(*tasks, return_exceptions=True)
+                # Persist whatever was accumulated so resume works
+                step_values[step.name] = results
+                if on_partial_checkpoint is not None and completed_count > 0:
                     on_partial_checkpoint(step.name, results, completed_count)
+                raise
         else:
 
             async def _tracked_row(idx: int):
@@ -920,8 +941,11 @@ class Pipeline:
 
                     if on_error == "raise":
                         step_values[step.name] = results
+                        # Cancel and drain remaining tasks before raising
                         for t in tasks:
-                            t.cancel()
+                            if not t.done():
+                                t.cancel()
+                        await asyncio.gather(*tasks, return_exceptions=True)
                         raise exc
                 else:
                     results[idx] = result_or_none.values

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pandas as pd
 import pytest
 
@@ -164,3 +166,107 @@ class TestEnricherWithErrors:
         assert result.at[0, "f"] == "f_value_0"
         assert pd.isna(result.at[1, "f"])  # failed row
         assert result.at[2, "f"] == "f_value_2"
+
+
+# -- Cancellation / drain correctness ----------------------------------------
+
+
+class TestCancellationFlushesPartialState:
+    @pytest.mark.asyncio
+    async def test_cancellation_flushes_step_values_and_calls_checkpoint(self):
+        """CancelledError mid-step persists accumulated results and invokes on_partial_checkpoint.
+
+        Strategy: rows sleep for increasing durations so cancellation lands when
+        some are done and others are still in-flight, guaranteeing completed_count > 0.
+        """
+        partial_calls: list[tuple[str, int]] = []
+
+        def on_partial(step_name: str, results: list, count: int) -> None:
+            partial_calls.append((step_name, count))
+
+        # Rows sleep idx * 0.05s — row 0 is instant, row 9 sleeps 0.45s.
+        # With max_workers=10 all start at once; rows 0-2 complete by ~0.10s.
+        async def staggered_fn(ctx):
+            idx = ctx.row.get("__idx", 0)
+            await asyncio.sleep(idx * 0.05)
+            return {"f": idx}
+
+        step = FunctionStep("slow", fn=staggered_fn, fields=["f"])
+        p = Pipeline([step])
+        rows = [{"__idx": i} for i in range(10)]
+        # checkpoint_interval=2: callback fires after rows 2, 4, … complete
+        config = EnrichmentConfig(checkpoint_interval=2, max_workers=10)
+
+        async def run():
+            return await p.execute(
+                rows,
+                all_fields={},
+                config=config,
+                on_partial_checkpoint=on_partial,
+            )
+
+        task = asyncio.create_task(run())
+        # Rows 0-2 complete in ~0.0–0.10s; cancel after they're done but before 9 finishes
+        await asyncio.sleep(0.12)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # At least one checkpoint call happened (rows 0-2 done → completed_count hit 2)
+        assert len(partial_calls) >= 1, "on_partial_checkpoint was never called after cancellation"
+        assert all(name == "slow" for name, _ in partial_calls)
+
+
+class TestLevelGatherSiblingsAwaited:
+    @pytest.mark.asyncio
+    async def test_on_error_raise_does_not_leave_orphaned_tasks(self):
+        """Parallel steps at the same level: one fails, siblings are awaited not dropped."""
+        finished_b: list[bool] = []
+
+        async def fast_fail(ctx):
+            raise StepError("deliberate", step_name="step_a")
+
+        async def slow_b(ctx):
+            await asyncio.sleep(0.05)
+            finished_b.append(True)
+            return {"b": 1}
+
+        p = Pipeline(
+            [
+                FunctionStep("step_a", fn=fast_fail, fields=["a"]),
+                FunctionStep("step_b", fn=slow_b, fields=["b"]),
+            ]
+        )
+        rows = [{"x": 1}]
+        config = EnrichmentConfig(on_error="raise", max_workers=2)
+
+        with pytest.raises(StepError, match="deliberate"):
+            await p.execute(rows, all_fields={}, config=config)
+
+        # After the raise, all tasks created inside _execute_step must be done
+        remaining = [t for t in asyncio.all_tasks() if not t.done()]
+        step_tasks = [t for t in remaining if "tracked_row" in repr(t) or "process_row" in repr(t)]
+        assert step_tasks == [], f"Orphaned step tasks found: {step_tasks}"
+
+
+class TestOnErrorContinueRegression:
+    @pytest.mark.asyncio
+    async def test_continue_mode_collects_errors_and_succeeds(self):
+        """on_error='continue' keeps going; success_rate reflects failures."""
+        p = Pipeline([_failing_step("s", ["f"], fail_indices={1, 3})])
+        rows = [{"__idx": i} for i in range(5)]
+        config = EnrichmentConfig(on_error="continue")
+
+        results, errors, cost = await p.execute(rows, all_fields={}, config=config)
+
+        assert len(errors) == 2
+        failed = {e.row_index for e in errors}
+        assert failed == {1, 3}
+        # Successful rows still have values
+        assert results[0]["f"] == "f_value_0"
+        assert results[2]["f"] == "f_value_2"
+        assert results[4]["f"] == "f_value_4"
+        # Failed rows get None sentinel
+        assert results[1]["f"] is None
+        assert results[3]["f"] is None


### PR DESCRIPTION
## Summary
- Wraps the realtime `as_completed` loop in `try/except (CancelledError, KeyboardInterrupt)` to cancel + drain in-flight tasks, persist accumulated results to `step_values`, and call `on_partial_checkpoint` before re-raising
- Switches `asyncio.gather(*level_coros)` to `return_exceptions=True` so one failing step at a DAG level doesn't cancel siblings without awaiting them; first exception is raised only after all siblings complete
- At every `t.cancel()` raise-path, adds `await asyncio.gather(*tasks, return_exceptions=True)` to drain tasks before control returns to the caller, preventing races against `cache_manager.close()`

## Changes
- `accrue/pipeline/pipeline.py`: three targeted fixes across `execute()` and `_execute_step()`
- `tests/test_error_handling.py`: three new tests for cancellation flush, sibling task drain, and on_error="continue" regression

## Testing
- All 504 existing tests pass
- New `TestCancellationFlushesPartialState`: cancels mid-flight pipeline, asserts `CancelledError` propagates and `on_partial_checkpoint` was called
- New `TestLevelGatherSiblingsAwaited`: parallel steps where one fails under `on_error="raise"`, asserts no orphaned tasks remain
- New `TestOnErrorContinueRegression`: confirms existing `on_error="continue"` semantics unchanged

## Checklist
- [x] Lint passes (`ruff check`)
- [x] Tests pass (`pytest -x -q`: 504 passed)
- [x] No evals framework in this repo — skip rationale: internal async correctness fix, no behavioral LLM output change
- [x] Labels applied (bug, priority:high)
- [x] Self-reviewed
- [x] No `asyncio.TaskGroup` used (project supports Python 3.10+)
- [x] Existing `on_error="continue"` behavior preserved

Closes #42