### PR TITLE
fix: narrow retry allowlist + full jitter + disable SDK retry stacking

### DIFF
--- a/accrue/steps/llm.py
+++ b/accrue/steps/llm.py
@@ -634,15 +634,15 @@ class LLMStep:
                 )
 
             except LLMAPIError as exc:
+                if not exc.retryable:
+                    raise
                 last_api_error = exc
                 if api_attempt < api_max_retries:
-                    # Exponential backoff with jitter
-                    delay = retry_base_delay * (2**api_attempt)
-                    # Respect Retry-After header if available
+                    # Full random jitter: uniform(0, base * 2^attempt)
+                    delay = random.uniform(0, retry_base_delay * (2**api_attempt))
+                    # Respect Retry-After header: use it as a floor
                     if exc.retry_after is not None:
-                        delay = max(delay, exc.retry_after)
-                    # Add jitter (0-25% of delay)
-                    delay += random.uniform(0, delay * 0.25)
+                        delay = max(delay, float(exc.retry_after))
                     logger.warning(
                         "LLMStep '%s' API error (attempt %d/%d), retrying in %.1fs: %s",
                         self.name,

--- a/accrue/steps/providers/anthropic.py
+++ b/accrue/steps/providers/anthropic.py
@@ -55,6 +55,9 @@ class AnthropicClient:
             kwargs: dict[str, Any] = {"api_key": key}
             if self._http_client is not None:
                 kwargs["http_client"] = self._http_client
+            # max_retries=0: disable SDK-level retry so LLMStep's retry loop
+            # is the single source of truth and retries are not double-stacked.
+            kwargs["max_retries"] = 0
             self._client = AsyncAnthropic(**kwargs)
         return self._client
 
@@ -137,9 +140,13 @@ class AnthropicClient:
                 status_code=408,
             ) from exc
         except APIError as exc:
+            exc_status = getattr(exc, "status_code", None)
+            # Promote generic 429 to is_rate_limit (covers cases where RateLimitError
+            # is not raised but status_code is 429)
             raise LLMAPIError(
                 f"Anthropic API error for model '{model}': {exc}",
-                status_code=getattr(exc, "status_code", None),
+                status_code=exc_status,
+                is_rate_limit=(exc_status == 429),
             ) from exc
 
         # Extract text from potentially multi-block response

--- a/accrue/steps/providers/base.py
+++ b/accrue/steps/providers/base.py
@@ -92,11 +92,34 @@ class LLMAPIError(Exception):
         status_code: int | None = None,
         retry_after: float | None = None,
         is_rate_limit: bool = False,
+        retryable: bool | None = None,
     ):
         super().__init__(message)
         self.status_code = status_code
         self.retry_after = retry_after
         self.is_rate_limit = is_rate_limit
+        self._retryable_override = retryable
+
+    @property
+    def retryable(self) -> bool:
+        """True when the error is safe to retry.
+
+        Retryable: rate-limit (429), timeout (408), and any 5xx server error.
+        Non-retryable: 400 (bad request / context_length_exceeded), 401 (auth),
+        403 (permission denied), 404 (not found), 422 (unprocessable), etc.
+        An explicit ``retryable=True/False`` passed to the constructor overrides
+        the automatic logic.
+        """
+        if self._retryable_override is not None:
+            return self._retryable_override
+        if self.is_rate_limit:
+            return True
+        if self.status_code is not None:
+            if self.status_code in {408, 429}:
+                return True
+            if self.status_code >= 500:
+                return True
+        return False
 
 
 # ---------------------------------------------------------------------------

--- a/accrue/steps/providers/openai.py
+++ b/accrue/steps/providers/openai.py
@@ -62,6 +62,9 @@ class OpenAIClient:
                 kwargs["base_url"] = self._base_url
             if self._http_client is not None:
                 kwargs["http_client"] = self._http_client
+            # max_retries=0: disable SDK-level retry so LLMStep's retry loop
+            # is the single source of truth and retries are not double-stacked.
+            kwargs["max_retries"] = 0
             self._client = AsyncOpenAI(**kwargs)
         return self._client
 
@@ -163,9 +166,12 @@ class OpenAIClient:
                 status_code=408,
             ) from exc
         except APIError as exc:
+            exc_status = getattr(exc, "status_code", None)
+            # Promote generic 429 to is_rate_limit (covers third-party OpenAI-compatible servers)
             raise LLMAPIError(
                 f"OpenAI API error for model '{model}': {exc}",
-                status_code=getattr(exc, "status_code", None),
+                status_code=exc_status,
+                is_rate_limit=(exc_status == 429),
             ) from exc
 
         # Extract content
@@ -236,9 +242,12 @@ class OpenAIClient:
                 status_code=408,
             ) from exc
         except APIError as exc:
+            exc_status = getattr(exc, "status_code", None)
+            # Promote generic 429 to is_rate_limit (covers third-party OpenAI-compatible servers)
             raise LLMAPIError(
                 f"OpenAI API error for model '{model}': {exc}",
-                status_code=getattr(exc, "status_code", None),
+                status_code=exc_status,
+                is_rate_limit=(exc_status == 429),
             ) from exc
 
         content = response.choices[0].message.content or ""

--- a/tests/test_llm_step.py
+++ b/tests/test_llm_step.py
@@ -158,7 +158,9 @@ class TestLLMStepClient:
         assert client is not None
         # Trigger lazy creation of the inner OpenAI SDK client
         client._get_client()
-        mock_cls.assert_called_once_with(api_key="test", base_url="http://localhost:11434/v1")
+        mock_cls.assert_called_once_with(
+            api_key="test", base_url="http://localhost:11434/v1", max_retries=0
+        )
 
     def test_client_reused(self):
         mock_client = AsyncMock()
@@ -711,6 +713,164 @@ class TestLLMStepAPIRetries:
         # Parse retries (1) exhausted, raises StepError (not caught by API retry)
         with pytest.raises(StepError, match="parse attempts"):
             await step.run(_make_ctx(config=config))
+
+
+# -- narrow retry allowlist ----------------------------------------------
+
+
+class TestNarrowRetryAllowlist:
+    """Non-retryable 4xx errors should not be retried (raises immediately)."""
+
+    @pytest.mark.asyncio
+    async def test_bad_request_not_retried(self):
+        """400 BadRequest (e.g. context_length_exceeded) raises after exactly 1 call."""
+        mock_client = AsyncMock()
+        mock_client.complete = AsyncMock(side_effect=LLMAPIError("bad request", status_code=400))
+        config = EnrichmentConfig(max_retries=3, retry_base_delay=0.001)
+        step = LLMStep(name="llm", fields={"f1": "test"}, client=mock_client)
+
+        with pytest.raises(LLMAPIError):
+            await step.run(_make_ctx(config=config))
+
+        # Must not retry — exactly 1 call
+        assert mock_client.complete.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_auth_error_not_retried(self):
+        """401 AuthenticationError raises after exactly 1 call."""
+        mock_client = AsyncMock()
+        mock_client.complete = AsyncMock(side_effect=LLMAPIError("unauthorized", status_code=401))
+        config = EnrichmentConfig(max_retries=3, retry_base_delay=0.001)
+        step = LLMStep(name="llm", fields={"f1": "test"}, client=mock_client)
+
+        with pytest.raises(LLMAPIError):
+            await step.run(_make_ctx(config=config))
+
+        assert mock_client.complete.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_permission_denied_not_retried(self):
+        """403 PermissionDenied raises after exactly 1 call."""
+        mock_client = AsyncMock()
+        mock_client.complete = AsyncMock(side_effect=LLMAPIError("forbidden", status_code=403))
+        config = EnrichmentConfig(max_retries=3, retry_base_delay=0.001)
+        step = LLMStep(name="llm", fields={"f1": "test"}, client=mock_client)
+
+        with pytest.raises(LLMAPIError):
+            await step.run(_make_ctx(config=config))
+
+        assert mock_client.complete.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_not_found_not_retried(self):
+        """404 NotFound raises after exactly 1 call."""
+        mock_client = AsyncMock()
+        mock_client.complete = AsyncMock(side_effect=LLMAPIError("not found", status_code=404))
+        config = EnrichmentConfig(max_retries=3, retry_base_delay=0.001)
+        step = LLMStep(name="llm", fields={"f1": "test"}, client=mock_client)
+
+        with pytest.raises(LLMAPIError):
+            await step.run(_make_ctx(config=config))
+
+        assert mock_client.complete.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_5xx_retried(self):
+        """503 Service Unavailable is retried."""
+        good_resp = _mock_llm_response(json.dumps({"f1": "ok"}))
+        mock_client = AsyncMock()
+        mock_client.complete = AsyncMock(
+            side_effect=[
+                LLMAPIError("service unavailable", status_code=503),
+                good_resp,
+            ]
+        )
+        config = EnrichmentConfig(max_retries=2, retry_base_delay=0.001)
+        step = LLMStep(name="llm", fields={"f1": "test"}, client=mock_client)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await step.run(_make_ctx(config=config))
+
+        assert result.values == {"f1": "ok"}
+        assert mock_client.complete.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_retried_exactly_twice(self):
+        """RateLimitError: first call raises, second succeeds. Assert exactly 2 calls."""
+        good_resp = _mock_llm_response(json.dumps({"f1": "ok"}))
+        mock_client = AsyncMock()
+        mock_client.complete = AsyncMock(
+            side_effect=[
+                LLMAPIError("rate limited", status_code=429, is_rate_limit=True),
+                good_resp,
+            ]
+        )
+        config = EnrichmentConfig(max_retries=3, retry_base_delay=0.001)
+        step = LLMStep(name="llm", fields={"f1": "test"}, client=mock_client)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await step.run(_make_ctx(config=config))
+
+        assert result.values == {"f1": "ok"}
+        assert mock_client.complete.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_full_jitter_uses_random_uniform(self):
+        """Jitter uses random.uniform(0, base * 2^attempt)."""
+        import random
+
+        good_resp = _mock_llm_response(json.dumps({"f1": "ok"}))
+        mock_client = AsyncMock()
+        mock_client.complete = AsyncMock(
+            side_effect=[
+                LLMAPIError("rate limited", status_code=429, is_rate_limit=True),
+                good_resp,
+            ]
+        )
+        config = EnrichmentConfig(max_retries=2, retry_base_delay=1.0)
+        step = LLMStep(name="llm", fields={"f1": "test"}, client=mock_client)
+
+        uniform_calls = []
+
+        original_uniform = random.uniform
+
+        def recording_uniform(a, b):
+            uniform_calls.append((a, b))
+            return 0.0  # return 0 so sleep is fast
+
+        with patch("accrue.steps.llm.random.uniform", side_effect=recording_uniform):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                await step.run(_make_ctx(config=config))
+
+        # Should have called random.uniform once for api_attempt=0: (0, 1.0 * 2**0) = (0, 1.0)
+        assert len(uniform_calls) >= 1
+        assert uniform_calls[0] == (0, 1.0)
+
+    @pytest.mark.asyncio
+    async def test_retry_after_floor(self):
+        """retry_after=2.0 is honoured as a floor even when jitter computes less."""
+        good_resp = _mock_llm_response(json.dumps({"f1": "ok"}))
+        mock_client = AsyncMock()
+        mock_client.complete = AsyncMock(
+            side_effect=[
+                LLMAPIError("rate limited", status_code=429, retry_after=2.0, is_rate_limit=True),
+                good_resp,
+            ]
+        )
+        config = EnrichmentConfig(max_retries=2, retry_base_delay=0.001)
+        step = LLMStep(name="llm", fields={"f1": "test"}, client=mock_client)
+
+        slept_delays = []
+
+        async def recording_sleep(delay):
+            slept_delays.append(delay)
+
+        with patch("accrue.steps.llm.random.uniform", return_value=0.0):
+            with patch("asyncio.sleep", side_effect=recording_sleep):
+                await step.run(_make_ctx(config=config))
+
+        # The delay should have been floored to retry_after=2.0
+        assert slept_delays[0] >= 2.0
 
 
 # -- custom schema -------------------------------------------------------

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -50,6 +50,147 @@ class TestLLMAPIError:
         e = LLMAPIError("rate limited", retry_after=2.5, is_rate_limit=True)
         assert e.retry_after == 2.5
 
+    # -- retryable property ------------------------------------------------
+
+    def test_retryable_rate_limit_flag(self):
+        e = LLMAPIError("rate limited", is_rate_limit=True)
+        assert e.retryable is True
+
+    def test_retryable_status_429(self):
+        e = LLMAPIError("429 error", status_code=429)
+        assert e.retryable is True
+
+    def test_retryable_status_408(self):
+        e = LLMAPIError("timeout", status_code=408)
+        assert e.retryable is True
+
+    def test_retryable_status_500(self):
+        e = LLMAPIError("internal server error", status_code=500)
+        assert e.retryable is True
+
+    def test_retryable_status_503(self):
+        e = LLMAPIError("service unavailable", status_code=503)
+        assert e.retryable is True
+
+    def test_not_retryable_status_400(self):
+        e = LLMAPIError("bad request", status_code=400)
+        assert e.retryable is False
+
+    def test_not_retryable_status_401(self):
+        e = LLMAPIError("unauthorized", status_code=401)
+        assert e.retryable is False
+
+    def test_not_retryable_status_403(self):
+        e = LLMAPIError("forbidden", status_code=403)
+        assert e.retryable is False
+
+    def test_not_retryable_status_404(self):
+        e = LLMAPIError("not found", status_code=404)
+        assert e.retryable is False
+
+    def test_not_retryable_status_422(self):
+        e = LLMAPIError("unprocessable", status_code=422)
+        assert e.retryable is False
+
+    def test_not_retryable_no_status(self):
+        e = LLMAPIError("generic error")
+        assert e.retryable is False
+
+    def test_retryable_override_true(self):
+        """explicit retryable=True overrides the auto-logic."""
+        e = LLMAPIError("bad req", status_code=400, retryable=True)
+        assert e.retryable is True
+
+    def test_retryable_override_false(self):
+        """explicit retryable=False overrides the auto-logic."""
+        e = LLMAPIError("rate limited", status_code=429, is_rate_limit=True, retryable=False)
+        assert e.retryable is False
+
+    def test_third_party_429_promoted(self):
+        """Generic APIError with status_code=429 is treated as rate-limit retryable."""
+        e = LLMAPIError("429 from third-party server", status_code=429, is_rate_limit=True)
+        assert e.retryable is True
+        assert e.is_rate_limit is True
+
+
+# -- SDK max_retries=0 checks ---------------------------------------------
+
+
+class TestSDKMaxRetries:
+    """Verify that provider clients pass max_retries=0 to their SDKs."""
+
+    @patch("openai.AsyncOpenAI")
+    def test_openai_client_max_retries_zero(self, mock_cls):
+        """OpenAIClient constructs AsyncOpenAI with max_retries=0."""
+        client = OpenAIClient(api_key="key")
+        client._get_client()
+        call_kwargs = mock_cls.call_args.kwargs
+        assert call_kwargs["max_retries"] == 0
+
+    @patch("openai.AsyncOpenAI")
+    def test_openai_client_with_base_url_max_retries_zero(self, mock_cls):
+        """OpenAIClient (base_url) also passes max_retries=0."""
+        client = OpenAIClient(api_key="key", base_url="http://localhost:11434/v1")
+        client._get_client()
+        call_kwargs = mock_cls.call_args.kwargs
+        assert call_kwargs["max_retries"] == 0
+
+    def test_anthropic_client_max_retries_zero(self):
+        """AnthropicClient constructs AsyncAnthropic with max_retries=0."""
+        import sys
+        from unittest.mock import MagicMock
+
+        mock_mod = MagicMock()
+        mock_mod.AsyncAnthropic = MagicMock()
+        sys.modules.setdefault("anthropic", mock_mod)
+
+        from accrue.steps.providers.anthropic import AnthropicClient
+
+        client = AnthropicClient(api_key="test-key")
+        client._get_client()
+
+        call_kwargs = mock_mod.AsyncAnthropic.call_args.kwargs
+        assert call_kwargs["max_retries"] == 0
+
+
+# -- Third-party 429 promoted to is_rate_limit ----------------------------
+
+
+class TestThirdParty429Promotion:
+    """Generic APIError with status_code=429 is promoted to is_rate_limit."""
+
+    @pytest.mark.asyncio
+    async def test_chat_completions_generic_429_promoted(self):
+        """A third-party OpenAI-compatible server returning 429 via generic APIError
+        is wrapped with is_rate_limit=True so the retry loop treats it as retryable."""
+        from openai import APIError
+
+        # Simulate a third-party server raising APIError (not RateLimitError) with 429
+        exc = APIError(
+            message="too many requests",
+            request=MagicMock(),
+            body=None,
+        )
+        exc.status_code = 429
+
+        mock_inner = MagicMock()
+        mock_inner.chat.completions.create = AsyncMock(side_effect=exc)
+
+        client = OpenAIClient(api_key="test", base_url="http://third-party:8080/v1")
+        client._client = mock_inner
+
+        with pytest.raises(LLMAPIError) as exc_info:
+            await client.complete(
+                messages=[{"role": "user", "content": "hi"}],
+                model="my-model",
+                temperature=0.0,
+                max_tokens=10,
+            )
+
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.is_rate_limit is True
+        assert exc_info.value.retryable is True
+
 
 # -- LLMClient protocol check -------------------------------------------
 
@@ -71,7 +212,7 @@ class TestOpenAIClientResponses:
         client = OpenAIClient(api_key="key123")
         assert client._client is None
         inner = client._get_client()
-        mock_cls.assert_called_once_with(api_key="key123")
+        mock_cls.assert_called_once_with(api_key="key123", max_retries=0)
         assert inner is mock_cls.return_value
 
     @pytest.mark.asyncio
@@ -399,7 +540,9 @@ class TestOpenAIClientChatCompletions:
     def test_base_url_passed_to_sdk(self, mock_cls):
         client = OpenAIClient(api_key="key", base_url="http://localhost:11434/v1")
         client._get_client()
-        mock_cls.assert_called_once_with(api_key="key", base_url="http://localhost:11434/v1")
+        mock_cls.assert_called_once_with(
+            api_key="key", base_url="http://localhost:11434/v1", max_retries=0
+        )
 
     @pytest.mark.asyncio
     async def test_complete_uses_chat_completions(self):


### PR DESCRIPTION
## Summary

- Adds `LLMAPIError.retryable` property: only 429, 408, and 5xx are retryable; 400/401/403/404/422 raise immediately without wasting retry budget
- Replaces deterministic backoff with full random jitter (`random.uniform(0, base * 2^attempt)`); Retry-After header is honoured as a floor
- Passes `max_retries=0` to `AsyncOpenAI` and `AsyncAnthropic` constructors so the SDK's built-in retry loop doesn't stack on top of LLMStep's loop
- Promotes generic `APIError(status_code=429)` from third-party OpenAI-compatible servers to `is_rate_limit=True`

## Test plan

- [ ] `TestLLMAPIError` — retryable property: rate-limit, 408, 5xx → True; 400/401/403/404/422 → False; override works
- [ ] `TestSDKMaxRetries` — OpenAI and Anthropic SDK clients constructed with `max_retries=0`
- [ ] `TestThirdParty429Promotion` — generic APIError(status_code=429) wrapped with `is_rate_limit=True`
- [ ] `TestNarrowRetryAllowlist` — 400/401/403/404 raise after 1 call; 503 retries; rate-limit retries exactly 2 times; jitter uses `random.uniform`; retry_after=2.0 floored correctly
- [ ] Full suite: `pytest -x -q` → 561 passed, ruff clean

## Existing tests adapted

- `TestOpenAIClientResponses.test_lazy_client_creation`: updated expected call args to include `max_retries=0`
- `TestOpenAIClientChatCompletions.test_base_url_passed_to_sdk`: same
- `TestLLMStepClient.test_base_url_creates_openai_client`: same

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)