### PR TITLE
fix(batch): custom_id uniqueness, CancelledError cleanup, anthropic grounding+schema warning (#47)

### DIFF
--- a/accrue/steps/providers/anthropic.py
+++ b/accrue/steps/providers/anthropic.py
@@ -108,6 +108,13 @@ class AnthropicClient:
         # Structured outputs: Anthropic uses output_config.format (GA)
         # json_schema → constrained decoding; json_object → no equivalent, skip
         # IMPORTANT: output_config.format is incompatible with web search citations
+        if anthropic_tools and response_format and response_format.get("type") == "json_schema":
+            logger.warning(
+                "Anthropic grounding (web search tools) is incompatible with strict "
+                "structured outputs; structured output schema will not be enforced for "
+                "this request. Consider running a separate non-grounded LLMStep over "
+                "the grounded context, or disable grounding for this step."
+            )
         if not anthropic_tools and response_format and response_format.get("type") == "json_schema":
             inner = response_format.get("json_schema", {})
             schema = inner.get("schema", {})
@@ -183,6 +190,15 @@ class AnthropicClient:
             The Anthropic batch ID.
         """
         client = self._get_client()
+
+        # Validate custom_id uniqueness before touching the network
+        seen: set[str] = set()
+        for req in requests:
+            if not req.custom_id:
+                raise ValueError("BatchRequest.custom_id must be non-empty")
+            if req.custom_id in seen:
+                raise ValueError(f"Duplicate custom_id in batch: {req.custom_id!r}")
+            seen.add(req.custom_id)
 
         anthropic_requests = []
         for req in requests:
@@ -261,38 +277,47 @@ class AnthropicClient:
         client = self._get_client()
         start = time.monotonic()
 
-        while True:
-            try:
-                batch = await client.messages.batches.retrieve(batch_id)
-            except Exception as exc:
-                raise StepError(
-                    f"Anthropic batch status check failed for {batch_id}: {exc}",
-                    step_name="batch",
-                ) from exc
+        try:
+            while True:
+                try:
+                    batch = await client.messages.batches.retrieve(batch_id)
+                except Exception as exc:
+                    raise StepError(
+                        f"Anthropic batch status check failed for {batch_id}: {exc}",
+                        step_name="batch",
+                    ) from exc
 
-            status = batch.processing_status
-            elapsed = time.monotonic() - start
+                status = batch.processing_status
+                elapsed = time.monotonic() - start
 
-            if status == "ended":
-                logger.info("Anthropic batch %s ended (%.0fs elapsed)", batch_id, elapsed)
-                return await self._collect_batch_results(client, batch_id)
+                if status == "ended":
+                    logger.info("Anthropic batch %s ended (%.0fs elapsed)", batch_id, elapsed)
+                    return await self._collect_batch_results(client, batch_id)
 
-            if elapsed > timeout:
-                raise StepError(
-                    f"Anthropic batch {batch_id} timed out after {elapsed:.0f}s "
-                    f"(status={status}). Check the Anthropic dashboard with "
-                    f"batch ID {batch_id}.",
-                    step_name="batch",
+                if elapsed > timeout:
+                    raise StepError(
+                        f"Anthropic batch {batch_id} timed out after {elapsed:.0f}s "
+                        f"(status={status}). Check the Anthropic dashboard with "
+                        f"batch ID {batch_id}.",
+                        step_name="batch",
+                    )
+
+                logger.info(
+                    "Anthropic batch %s status=%s (%.0fs elapsed), next check in %.0fs",
+                    batch_id,
+                    status,
+                    elapsed,
+                    poll_interval,
                 )
-
-            logger.info(
-                "Anthropic batch %s status=%s (%.0fs elapsed), next check in %.0fs",
-                batch_id,
-                status,
-                elapsed,
-                poll_interval,
-            )
-            await asyncio.sleep(poll_interval)
+                await asyncio.sleep(poll_interval)
+        except (asyncio.CancelledError, KeyboardInterrupt):
+            # User cancelled — best-effort cancel the upstream batch to avoid
+            # orphaning a billable job.
+            try:
+                await self.cancel_batch(batch_id)
+            except Exception:
+                pass  # cancel_batch is best-effort; don't mask the original interruption
+            raise
 
     async def cancel_batch(self, batch_id: str) -> None:
         """Best-effort cancel an Anthropic batch.

--- a/accrue/steps/providers/openai.py
+++ b/accrue/steps/providers/openai.py
@@ -286,6 +286,15 @@ class OpenAIClient:
 
         client = self._get_client()
 
+        # Validate custom_id uniqueness before touching the network
+        seen: set[str] = set()
+        for req in requests:
+            if not req.custom_id:
+                raise ValueError("BatchRequest.custom_id must be non-empty")
+            if req.custom_id in seen:
+                raise ValueError(f"Duplicate custom_id in batch: {req.custom_id!r}")
+            seen.add(req.custom_id)
+
         # Build JSONL content
         jsonl_lines: list[str] = []
         for req in requests:
@@ -360,52 +369,60 @@ class OpenAIClient:
         client = self._get_client()
         start = time.monotonic()
 
-        while True:
+        try:
+            while True:
+                try:
+                    batch = await client.batches.retrieve(batch_id)
+                except APIError as exc:
+                    raise StepError(
+                        f"OpenAI batch status check failed for {batch_id}: {exc}",
+                        step_name="batch",
+                    ) from exc
+
+                status = batch.status
+                elapsed = time.monotonic() - start
+
+                if status == "completed":
+                    logger.info("OpenAI batch %s completed (%.0fs elapsed)", batch_id, elapsed)
+                    return await self._download_batch_results(batch, batch_id)
+
+                if status in ("failed", "expired", "cancelled"):
+                    error_info = ""
+                    if hasattr(batch, "errors") and batch.errors:
+                        error_data = getattr(batch.errors, "data", [])
+                        if error_data:
+                            msgs = [getattr(e, "message", str(e)) for e in error_data[:3]]
+                            error_info = f" Errors: {msgs}"
+                    raise StepError(
+                        f"OpenAI batch {batch_id} {status} after {elapsed:.0f}s.{error_info} "
+                        f"Check the OpenAI dashboard for details.",
+                        step_name="batch",
+                    )
+
+                if elapsed > timeout:
+                    raise StepError(
+                        f"OpenAI batch {batch_id} timed out after {elapsed:.0f}s "
+                        f"(status={status}). The batch may still be processing — "
+                        f"check the OpenAI dashboard with batch ID {batch_id}.",
+                        step_name="batch",
+                    )
+
+                logger.info(
+                    "OpenAI batch %s status=%s (%.0fs elapsed), next check in %.0fs",
+                    batch_id,
+                    status,
+                    elapsed,
+                    poll_interval,
+                )
+                await asyncio.sleep(poll_interval)
+        except (asyncio.CancelledError, KeyboardInterrupt):
+            # User cancelled — best-effort cancel the upstream batch to avoid
+            # orphaning a billable job.
             try:
-                batch = await client.batches.retrieve(batch_id)
-            except APIError as exc:
-                raise StepError(
-                    f"OpenAI batch status check failed for {batch_id}: {exc}",
-                    step_name="batch",
-                ) from exc
-
-            status = batch.status
-            elapsed = time.monotonic() - start
-
-            if status == "completed":
-                logger.info("OpenAI batch %s completed (%.0fs elapsed)", batch_id, elapsed)
-                return await self._download_batch_results(batch, batch_id)
-
-            if status in ("failed", "expired", "cancelled"):
-                error_info = ""
-                if hasattr(batch, "errors") and batch.errors:
-                    error_data = getattr(batch.errors, "data", [])
-                    if error_data:
-                        error_info = (
-                            f" Errors: {[getattr(e, 'message', str(e)) for e in error_data[:3]]}"
-                        )
-                raise StepError(
-                    f"OpenAI batch {batch_id} {status} after {elapsed:.0f}s.{error_info} "
-                    f"Check the OpenAI dashboard for details.",
-                    step_name="batch",
-                )
-
-            if elapsed > timeout:
-                raise StepError(
-                    f"OpenAI batch {batch_id} timed out after {elapsed:.0f}s "
-                    f"(status={status}). The batch may still be processing — "
-                    f"check the OpenAI dashboard with batch ID {batch_id}.",
-                    step_name="batch",
-                )
-
-            logger.info(
-                "OpenAI batch %s status=%s (%.0fs elapsed), next check in %.0fs",
-                batch_id,
-                status,
-                elapsed,
-                poll_interval,
-            )
-            await asyncio.sleep(poll_interval)
+                await self.cancel_batch(batch_id)
+            except Exception:
+                pass  # cancel_batch is best-effort; don't mask the original interruption
+            raise
 
     async def cancel_batch(self, batch_id: str) -> None:
         """Best-effort cancel an OpenAI batch job.

--- a/tests/test_batch_anthropic.py
+++ b/tests/test_batch_anthropic.py
@@ -273,3 +273,90 @@ class TestAnthropicCancelBatch:
 
         # Should not raise
         await client.cancel_batch("msgbatch_abc")
+
+
+# -- custom_id uniqueness ----------------------------------------------------
+
+
+class TestAnthropicSubmitBatchCustomIdValidation:
+    @pytest.mark.asyncio
+    async def test_duplicate_custom_id_raises(self):
+        from accrue.steps.providers.anthropic import AnthropicClient
+
+        client = AnthropicClient(api_key="test")
+        client._client = MagicMock()
+
+        req_a = _make_batch_request(0)
+        req_b = _make_batch_request(0)  # same index → same custom_id "row-0"
+
+        with pytest.raises(ValueError, match="Duplicate custom_id"):
+            await client.submit_batch([req_a, req_b])
+
+
+# -- CancelledError cleanup --------------------------------------------------
+
+
+class TestAnthropicPollBatchCancelledError:
+    @pytest.mark.asyncio
+    async def test_cancelled_error_triggers_cancel_batch(self):
+        """CancelledError during polling must call cancel_batch before re-raising."""
+        import asyncio
+
+        from accrue.steps.providers.anthropic import AnthropicClient
+
+        mock_inner = MagicMock()
+        mock_inner.messages.batches.retrieve = AsyncMock(side_effect=asyncio.CancelledError())
+        mock_inner.messages.batches.cancel = AsyncMock()
+
+        client = AnthropicClient(api_key="test")
+        client._client = mock_inner
+
+        with pytest.raises((asyncio.CancelledError, BaseException)):
+            await client.poll_batch("msgbatch_abc", poll_interval=0.01)
+
+        mock_inner.messages.batches.cancel.assert_called_once_with("msgbatch_abc")
+
+
+# -- grounding + json_schema warning -----------------------------------------
+
+
+class TestAnthropicGroundingSchemaWarning:
+    @pytest.mark.asyncio
+    async def test_grounding_plus_json_schema_logs_warning(self, caplog):
+        """When both grounding tools and json_schema are set, a WARNING is emitted."""
+        import logging
+
+        from accrue.steps.providers.anthropic import AnthropicClient
+
+        mock_inner = MagicMock()
+
+        # Build a minimal successful response object
+        mock_response = SimpleNamespace(
+            content=[SimpleNamespace(type="text", text='{"result": "ok"}')],
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        )
+        mock_inner.messages.create = AsyncMock(return_value=mock_response)
+
+        client = AnthropicClient(api_key="test")
+        client._client = mock_inner
+
+        tools = [{"type": "web_search"}]
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {"schema": {"type": "object"}, "name": "result"},
+        }
+
+        with caplog.at_level(logging.WARNING, logger="accrue.steps.providers.anthropic"):
+            await client.complete(
+                messages=[{"role": "user", "content": "search for something"}],
+                model="claude-sonnet-4-20250514",
+                temperature=0.2,
+                max_tokens=1000,
+                response_format=response_format,
+                tools=tools,
+            )
+
+        warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("grounding" in msg and "structured output" in msg for msg in warning_messages), (
+            f"Expected grounding+schema warning, got: {warning_messages}"
+        )

--- a/tests/test_batch_openai.py
+++ b/tests/test_batch_openai.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -320,3 +321,50 @@ class TestCancelBatch:
 
         # Should not raise
         await adapter.cancel_batch("batch-abc")
+
+
+# -- custom_id uniqueness ----------------------------------------------------
+
+
+class TestSubmitBatchCustomIdValidation:
+    @pytest.mark.asyncio
+    async def test_duplicate_custom_id_raises(self):
+        adapter = OpenAIClient(api_key="test")
+        adapter._client = MagicMock()
+
+        req_a = _make_batch_request(0)
+        req_b = _make_batch_request(0)  # same index → same custom_id "row-0"
+
+        with pytest.raises(ValueError, match="Duplicate custom_id"):
+            await adapter.submit_batch([req_a, req_b])
+
+    @pytest.mark.asyncio
+    async def test_empty_custom_id_raises(self):
+        adapter = OpenAIClient(api_key="test")
+        adapter._client = MagicMock()
+
+        req = _make_batch_request(0)
+        req.custom_id = ""
+
+        with pytest.raises(ValueError, match="custom_id must be non-empty"):
+            await adapter.submit_batch([req])
+
+
+# -- CancelledError cleanup --------------------------------------------------
+
+
+class TestPollBatchCancelledError:
+    @pytest.mark.asyncio
+    async def test_cancelled_error_triggers_cancel_batch(self):
+        """CancelledError during polling must call cancel_batch before re-raising."""
+        mock_client = MagicMock()
+        mock_client.batches.retrieve = AsyncMock(side_effect=asyncio.CancelledError())
+        mock_client.batches.cancel = AsyncMock()
+
+        adapter = OpenAIClient(api_key="test")
+        adapter._client = mock_client
+
+        with pytest.raises(asyncio.CancelledError):
+            await adapter.poll_batch("batch-abc", poll_interval=0.01)
+
+        mock_client.batches.cancel.assert_called_once_with("batch-abc")


### PR DESCRIPTION
## Summary

- `submit_batch` (OpenAI and Anthropic) now validates `custom_id` uniqueness and non-emptiness before uploading, preventing silent row overwrites during response assembly
- `poll_batch` (both adapters) wraps the polling loop in `try/except (CancelledError, KeyboardInterrupt)` and calls `cancel_batch` best-effort before re-raising, preventing orphaned billable batch jobs
- Anthropic `complete()` logs a `WARNING` when both grounding tools and `json_schema` response format are set, surfacing the silent schema drop that was previously invisible

## Changes

- `accrue/steps/providers/openai.py`: uniqueness check in `submit_batch`; CancelledError cleanup in `poll_batch`
- `accrue/steps/providers/anthropic.py`: uniqueness check in `submit_batch`; CancelledError cleanup in `poll_batch`; grounding+schema warning in `complete()`
- `tests/test_batch_openai.py`: 3 new tests (duplicate custom_id raises, empty custom_id raises, CancelledError triggers cancel_batch)
- `tests/test_batch_anthropic.py`: 3 new tests (duplicate custom_id raises, CancelledError triggers cancel_batch, grounding+json_schema logs warning)

## Testing

26 batch tests pass (15 OpenAI + 11 Anthropic). `ruff check` and `ruff format --check` clean.

## Evals

No eval framework in this repo (`evals/` directory does not exist). Skipping.

## Checklist

- [x] Lint passes
- [x] Tests pass (26/26)
- [x] No evals framework present — skip rationale recorded
- [x] Labels copied from source issue applied
- [x] Self-reviewed
- [x] No architectural decisions made — no ADR needed
- [x] `CLAUDE.md` unchanged (no architecture changes)

Closes #47