### PR TITLE
fix(checkpoint): distinguish partial vs complete checkpoint writes (#58)

### DIFF
--- a/accrue/core/checkpoint.py
+++ b/accrue/core/checkpoint.py
@@ -120,19 +120,29 @@ class CheckpointManager:
         fields_dict: dict[str, dict[str, Any]],
         existing_completed: list[str],
         existing_results: dict[str, list[dict[str, Any]]],
+        *,
+        partial: bool = False,
     ) -> bool:
         """Write full pipeline state to disk after a step completes.
 
         Uses an atomic write (tmp + fsync + os.replace) so a crash mid-write
         never corrupts the existing checkpoint.
 
+        Args:
+            partial: When True, save partial row results without marking the
+                step as completed.  On resume the step will re-run from
+                scratch, ensuring unfinished rows are never silently treated
+                as completed.  Defaults to False (normal completion).
+
         Returns True on success or when checkpointing is disabled (no-op).
         """
         if not self._enabled:
             return True
 
-        # Merge the newly completed step into existing state
-        completed = list(existing_completed) + [step_name]
+        # For a partial save, do NOT append step_name to completed_steps so
+        # that a resumed run re-executes the step from scratch instead of
+        # skipping it and propagating empty {} results downstream.
+        completed = list(existing_completed) if partial else list(existing_completed) + [step_name]
         results = dict(existing_results)
         results[step_name] = step_row_results
 

--- a/accrue/core/enricher.py
+++ b/accrue/core/enricher.py
@@ -175,6 +175,7 @@ class Enricher:
                     fields_dict=fields_dict,
                     existing_completed=list(cb_completed),
                     existing_results=dict(cb_results),
+                    partial=True,
                 )
 
         # Execute pipeline

--- a/accrue/core/enricher.py
+++ b/accrue/core/enricher.py
@@ -124,9 +124,11 @@ class Enricher:
             elif cp.fields_dict != fields_dict:
                 logger.warning("Checkpoint fields_dict mismatch, starting fresh")
             else:
-                prior_step_results = cp.step_results
                 completed_steps = list(cp.completed_steps)
-                checkpoint_results = dict(cp.step_results)
+                prior_step_results = {
+                    k: v for k, v in cp.step_results.items() if k in cp.completed_steps
+                }
+                checkpoint_results = dict(prior_step_results)
                 logger.info(f"Resuming from checkpoint: skipping {completed_steps}")
 
         # Convert DataFrame to rows

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -415,3 +415,90 @@ class TestTypedSerializer:
                 existing_completed=[],
                 existing_results={},
             )
+
+
+# -- partial checkpoint (partial=True) ---------------------------------------
+
+
+class TestPartialCheckpoint:
+    def test_partial_true_does_not_add_to_completed_steps(self, tmp_path):
+        """save_step(partial=True) must NOT append the step to completed_steps."""
+        mgr = _make_mgr(tmp_path)
+        row_results = [{"f": "partial_val"}, {}]
+
+        ok = mgr.save_step(
+            data_identifier="data",
+            category="cat",
+            step_name="step1",
+            step_row_results=row_results,
+            total_rows=2,
+            fields_dict=FIELDS,
+            existing_completed=[],
+            existing_results={},
+            partial=True,
+        )
+        assert ok is True
+
+        cp = mgr.load("data", "cat")
+        assert cp is not None
+        # Step must NOT appear in completed_steps so a resumed run re-executes it.
+        assert "step1" not in cp.completed_steps
+        assert cp.completed_steps == []
+        # Partial data is still persisted in step_results for tracking purposes.
+        assert cp.step_results["step1"] == row_results
+
+    def test_partial_false_default_adds_to_completed_steps(self, tmp_path):
+        """save_step(partial=False) (the default) DOES append to completed_steps."""
+        mgr = _make_mgr(tmp_path)
+        row_results = [{"f": "val"}]
+
+        mgr.save_step(
+            data_identifier="data",
+            category="cat",
+            step_name="step1",
+            step_row_results=row_results,
+            total_rows=1,
+            fields_dict=FIELDS,
+            existing_completed=[],
+            existing_results={},
+        )
+
+        cp = mgr.load("data", "cat")
+        assert cp is not None
+        assert "step1" in cp.completed_steps
+
+    def test_partial_preserves_prior_completed_steps_unchanged(self, tmp_path):
+        """Partial save must not disturb already-completed steps."""
+        mgr = _make_mgr(tmp_path)
+
+        # First step is fully completed.
+        step1_results = [{"f1": "done"}]
+        mgr.save_step(
+            data_identifier="data",
+            category="cat",
+            step_name="step1",
+            step_row_results=step1_results,
+            total_rows=1,
+            fields_dict=FIELDS,
+            existing_completed=[],
+            existing_results={},
+        )
+
+        # Second step is only partially done (e.g. cancelled mid-flight).
+        mgr.save_step(
+            data_identifier="data",
+            category="cat",
+            step_name="step2",
+            step_row_results=[{}],
+            total_rows=1,
+            fields_dict=FIELDS,
+            existing_completed=["step1"],
+            existing_results={"step1": step1_results},
+            partial=True,
+        )
+
+        cp = mgr.load("data", "cat")
+        assert cp is not None
+        # Only step1 is completed; step2 must NOT appear.
+        assert cp.completed_steps == ["step1"]
+        assert "step2" not in cp.completed_steps

--- a/tests/test_enricher.py
+++ b/tests/test_enricher.py
@@ -368,12 +368,22 @@ class TestCancelAndResume:
         num_rows = 10
         # rows_started tracks which row indices were actually processed by the step.
         rows_started: list[int] = []
+        # Deterministic synchronization: the main coroutine waits on this event
+        # so cancellation always lands while row 2 is mid-flight (rows 0-1 done,
+        # row 2 hanging, rows 3-9 not yet started).  This removes the timing
+        # dependency that made the previous version flaky on slow CI workers.
+        started_row_2 = asyncio.Event()
 
         async def slow_fn(ctx):
             row_idx = ctx.row.get("idx", -1)
             rows_started.append(row_idx)
-            # Introduce a small delay so we can cancel mid-flight.
-            await asyncio.sleep(0.05)
+            if row_idx == 2:
+                # Signal the main coroutine that row 2 has started, then hang
+                # long enough that cancellation arrives before the row finishes.
+                started_row_2.set()
+                await asyncio.sleep(10.0)
+            else:
+                await asyncio.sleep(0.01)
             return {"enriched": f"done_{row_idx}"}
 
         pipeline = Pipeline([FunctionStep("enrich", fn=slow_fn, fields=["enriched"])])
@@ -389,20 +399,20 @@ class TestCancelAndResume:
         enricher = Enricher(pipeline, config=config)
         df = pd.DataFrame({"idx": list(range(num_rows))})
 
-        # Run with a short timeout to force cancellation mid-step.
+        # Wait until row 2 is in-flight, then cancel — no wall-clock timeouts.
         task = asyncio.create_task(enricher.run_async(df, data_identifier="cancel_test"))
+        await started_row_2.wait()
+        task.cancel()
         try:
-            await asyncio.wait_for(asyncio.shield(task), timeout=0.15)
-        except (asyncio.TimeoutError, asyncio.CancelledError):
-            if not task.done():
-                task.cancel()
-                try:
-                    await task
-                except (asyncio.CancelledError, Exception):
-                    pass
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
 
         # Confirm we actually cancelled before finishing all rows.
         assert len(rows_started) < num_rows, "Test setup error: all rows completed before cancel"
+        # And confirm row 2 was the in-flight row (so the partial checkpoint has
+        # results for rows 0,1 only — row 2 was cancelled mid-flight).
+        assert 2 in rows_started, "Row 2 should have started before cancel"
 
         # Now resume with a fresh Enricher and confirm no {} leaks downstream.
         rows_started.clear()

--- a/tests/test_enricher.py
+++ b/tests/test_enricher.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 
 import pandas as pd
@@ -351,3 +352,66 @@ class TestStableDataIdentifier:
         # And the identifier must be a stable hex string (not an integer from hash()).
         assert id1.startswith("df_")
         assert len(id1) == len("df_") + 16
+
+
+# -- cancellation + resume (regression for partial-checkpoint corruption) -----
+
+
+class TestCancelAndResume:
+    @pytest.mark.asyncio
+    async def test_cancel_mid_step_resume_has_no_empty_rows(self, tmp_path):
+        """Cancel mid-step; resume must re-run the step — no {} placeholders downstream.
+
+        Regression for: on_partial_checkpoint used to mark the step completed,
+        so a resumed run would skip it and propagate empty {} for unfinished rows.
+        """
+        num_rows = 10
+        # rows_started tracks which row indices were actually processed by the step.
+        rows_started: list[int] = []
+
+        async def slow_fn(ctx):
+            row_idx = ctx.row.get("idx", -1)
+            rows_started.append(row_idx)
+            # Introduce a small delay so we can cancel mid-flight.
+            await asyncio.sleep(0.05)
+            return {"enriched": f"done_{row_idx}"}
+
+        pipeline = Pipeline([FunctionStep("enrich", fn=slow_fn, fields=["enriched"])])
+        config = EnrichmentConfig(
+            enable_checkpointing=True,
+            auto_resume=True,
+            checkpoint_dir=str(tmp_path),
+            # Fire a partial checkpoint after every row so the checkpoint is
+            # guaranteed to be written before the cancellation arrives.
+            checkpoint_interval=1,
+            max_workers=1,  # sequential to make cancellation timing deterministic
+        )
+        enricher = Enricher(pipeline, config=config)
+        df = pd.DataFrame({"idx": list(range(num_rows))})
+
+        # Run with a short timeout to force cancellation mid-step.
+        task = asyncio.create_task(enricher.run_async(df, data_identifier="cancel_test"))
+        try:
+            await asyncio.wait_for(asyncio.shield(task), timeout=0.15)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            if not task.done():
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+        # Confirm we actually cancelled before finishing all rows.
+        assert len(rows_started) < num_rows, "Test setup error: all rows completed before cancel"
+
+        # Now resume with a fresh Enricher and confirm no {} leaks downstream.
+        rows_started.clear()
+        enricher2 = Enricher(pipeline, config=config)
+        result = await enricher2.run_async(df, data_identifier="cancel_test")
+
+        enriched_col = list(result["enriched"])
+        # Every value must be non-empty — no {} placeholders from the partial save.
+        for i, val in enumerate(enriched_col):
+            assert val != {} and val is not None and val != "", (
+                f"Row {i} has empty/placeholder value after resume: {val!r}"
+            )


### PR DESCRIPTION
## Summary

- Fixes silent data corruption when a pipeline step is cancelled mid-flight via Ctrl-C
- A partial checkpoint save previously marked the step as fully `completed`, causing empty `{}` results to flow downstream as real data on resume
- Adds `partial: bool = False` kwarg to `CheckpointManager.save_step`; when `True`, step_results are persisted but the step is **not** appended to `completed_steps`, so resume re-runs it from scratch

## Changes

- `accrue/core/checkpoint.py`: add `partial` kwarg to `save_step`; skip appending to `completed_steps` when `partial=True`
- `accrue/core/enricher.py`: pass `partial=True` from `on_partial_checkpoint` closure
- `tests/test_checkpoint.py`: 3 new tests — `partial=True` contract, `partial=False` regression, preservation of prior completed steps
- `tests/test_enricher.py`: integration test — cancel mid-step, resume, assert no `{}` placeholders

## Testing

- `ruff check accrue/ tests/` — passes
- `ruff format --check accrue/ tests/` — passes
- `pytest tests/test_checkpoint.py tests/test_enricher.py tests/test_pipeline.py` — 68/68 passed

## Checklist
- [x] Lint passes
- [x] Tests pass
- [x] No evals framework present — skipped
- [x] Labels: `bug`, `priority:high` copied from issue #58
- [x] Self-reviewed

Closes #58