### PR TITLE
fix(enricher): pass expected_* kwargs to checkpoint load — enables strict validation

### DIFF
--- a/accrue/core/enricher.py
+++ b/accrue/core/enricher.py
@@ -114,22 +114,20 @@ class Enricher:
         completed_steps: list[str] = []
         checkpoint_results: dict[str, list[dict[str, Any]]] = {}
 
-        cp = self._checkpoint.load(data_identifier, category)
+        cp = self._checkpoint.load(
+            data_identifier,
+            category,
+            expected_total_rows=len(df),
+            expected_fields=fields_dict,
+            expected_steps=self.pipeline.step_names,
+        )
         if cp is not None:
-            # Validate checkpoint compatibility
-            if cp.total_rows != len(df):
-                logger.warning(
-                    f"Checkpoint row count mismatch ({cp.total_rows} vs {len(df)}), starting fresh"
-                )
-            elif cp.fields_dict != fields_dict:
-                logger.warning("Checkpoint fields_dict mismatch, starting fresh")
-            else:
-                completed_steps = list(cp.completed_steps)
-                prior_step_results = {
-                    k: v for k, v in cp.step_results.items() if k in cp.completed_steps
-                }
-                checkpoint_results = dict(prior_step_results)
-                logger.info(f"Resuming from checkpoint: skipping {completed_steps}")
+            completed_steps = list(cp.completed_steps)
+            prior_step_results = {
+                k: v for k, v in cp.step_results.items() if k in cp.completed_steps
+            }
+            checkpoint_results = dict(prior_step_results)
+            logger.info(f"Resuming from checkpoint: skipping {completed_steps}")
 
         # Convert DataFrame to rows
         rows = df.to_dict(orient="records")

--- a/tests/test_enricher.py
+++ b/tests/test_enricher.py
@@ -318,6 +318,196 @@ class TestCheckpointResume:
         files = list(tmp_path.glob("*_checkpoint.json"))
         assert len(files) == 0
 
+    # -- helpers for strict-validation tests ---------------------------------
+
+    @staticmethod
+    def _write_checkpoint(
+        tmp_path,
+        df_columns,
+        total_rows,
+        fields_dict,
+        completed_steps,
+        step_results,
+        category="_default",
+    ):
+        """Write a checkpoint file using the same path logic as CheckpointManager._get_path."""
+        import hashlib
+        import json as _json
+
+        identifier_source = _json.dumps(
+            {"columns": df_columns, "rows": total_rows}, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+        data_id = f"df_{hashlib.sha256(identifier_source).hexdigest()[:16]}"
+        # Mirror CheckpointManager._get_path exactly
+        safe_id = "".join(c if c.isalnum() or c in ("-", "_") else "_" for c in data_id)
+        safe_cat = "".join(c if c.isalnum() or c in ("-", "_") else "_" for c in category)
+        cp_path = tmp_path / f"{safe_id}_{safe_cat}_checkpoint.json"
+        checkpoint_data = {
+            "timestamp": 1000.0,
+            "category": category,
+            "total_rows": total_rows,
+            "fields_dict": fields_dict,
+            "completed_steps": completed_steps,
+            "step_results": step_results,
+        }
+        with open(cp_path, "w") as f:
+            _json.dump(checkpoint_data, f)
+        return cp_path
+
+    def test_renamed_step_discards_checkpoint(self, tmp_path, caplog):
+        """Checkpoint with steps ['a','b'] must be discarded when pipeline has 'a_v2'."""
+        import logging
+
+        call_tracker = {"calls": 0}
+
+        def fn(ctx):
+            call_tracker["calls"] += 1
+            return {"field1": "fresh"}
+
+        # Pipeline now has 'a_v2' instead of 'a'
+        pipeline = Pipeline([FunctionStep("a_v2", fn=fn, fields=["field1"])])
+
+        # Write checkpoint that has step 'a' completed (same fields, same rows)
+        self._write_checkpoint(
+            tmp_path,
+            df_columns=["x"],
+            total_rows=2,
+            fields_dict={"field1": {}},
+            completed_steps=["a"],
+            step_results={"a": [{"field1": "cached"}, {"field1": "cached"}]},
+        )
+
+        config = EnrichmentConfig(
+            enable_checkpointing=True,
+            auto_resume=True,
+            checkpoint_dir=str(tmp_path),
+        )
+        enricher = Enricher(pipeline, config=config)
+        df = pd.DataFrame({"x": [1, 2]})
+
+        with caplog.at_level(logging.WARNING):
+            result = enricher.run(df)
+
+        # Must re-run from scratch — step fn must have been called
+        assert call_tracker["calls"] == 2
+        # Result must come from fresh execution, not cached "cached" value
+        assert list(result["field1"]) == ["fresh", "fresh"]
+        # A warning about the unknown step must have been logged
+        assert any(
+            "unknown" in record.message.lower() or "discard" in record.message.lower()
+            for record in caplog.records
+        )
+
+    def test_row_count_mismatch_discards_checkpoint(self, tmp_path):
+        """Checkpoint with 3 rows must be discarded when the DataFrame has 2 rows."""
+        call_tracker = {"calls": 0}
+
+        def fn(ctx):
+            call_tracker["calls"] += 1
+            return {"out": "fresh"}
+
+        pipeline = Pipeline([FunctionStep("s", fn=fn, fields=["out"])])
+
+        # Write checkpoint with 3 rows, but we'll run with 2
+        self._write_checkpoint(
+            tmp_path,
+            df_columns=["x"],
+            total_rows=3,  # mismatch
+            fields_dict={"out": {}},
+            completed_steps=["s"],
+            step_results={"s": [{"out": "cached"}] * 3},
+        )
+
+        config = EnrichmentConfig(
+            enable_checkpointing=True,
+            auto_resume=True,
+            checkpoint_dir=str(tmp_path),
+        )
+        enricher = Enricher(pipeline, config=config)
+        df = pd.DataFrame({"x": [1, 2]})  # 2 rows
+        result = enricher.run(df)
+
+        # Must re-run from scratch
+        assert call_tracker["calls"] == 2
+        assert list(result["out"]) == ["fresh", "fresh"]
+
+    def test_field_mismatch_discards_checkpoint(self, tmp_path):
+        """Checkpoint with different fields must be discarded."""
+        call_tracker = {"calls": 0}
+
+        def fn(ctx):
+            call_tracker["calls"] += 1
+            return {"new_field": "fresh"}
+
+        pipeline = Pipeline([FunctionStep("s", fn=fn, fields=["new_field"])])
+
+        # Write checkpoint with different fields
+        self._write_checkpoint(
+            tmp_path,
+            df_columns=["x"],
+            total_rows=2,
+            fields_dict={"old_field": {}},  # mismatch
+            completed_steps=["s"],
+            step_results={"s": [{"old_field": "cached"}] * 2},
+        )
+
+        config = EnrichmentConfig(
+            enable_checkpointing=True,
+            auto_resume=True,
+            checkpoint_dir=str(tmp_path),
+        )
+        enricher = Enricher(pipeline, config=config)
+        df = pd.DataFrame({"x": [1, 2]})
+        result = enricher.run(df)
+
+        # Must re-run from scratch
+        assert call_tracker["calls"] == 2
+        assert list(result["new_field"]) == ["fresh", "fresh"]
+
+    def test_matching_shape_resumes_correctly(self, tmp_path):
+        """Checkpoint with matching rows, fields, and steps must resume (skip completed step)."""
+        call_tracker = {"step1_calls": 0, "step2_calls": 0}
+
+        def step1_fn(ctx):
+            call_tracker["step1_calls"] += 1
+            return {"f1": "live_val"}
+
+        def step2_fn(ctx):
+            call_tracker["step2_calls"] += 1
+            return {"f2": ctx.prior_results.get("f1", "") + "_done"}
+
+        pipeline = Pipeline(
+            [
+                FunctionStep("step1", fn=step1_fn, fields=["f1"]),
+                FunctionStep("step2", fn=step2_fn, fields=["f2"], depends_on=["step1"]),
+            ]
+        )
+
+        self._write_checkpoint(
+            tmp_path,
+            df_columns=["x"],
+            total_rows=2,
+            fields_dict={"f1": {}, "f2": {}},
+            completed_steps=["step1"],
+            step_results={"step1": [{"f1": "cached_val"}, {"f1": "cached_val2"}]},
+        )
+
+        config = EnrichmentConfig(
+            enable_checkpointing=True,
+            auto_resume=True,
+            checkpoint_dir=str(tmp_path),
+        )
+        enricher = Enricher(pipeline, config=config)
+        df = pd.DataFrame({"x": [1, 2]})
+        result = enricher.run(df)
+
+        # step1 must be skipped (it was checkpointed with matching state)
+        assert call_tracker["step1_calls"] == 0
+        # step2 must run using the cached step1 results
+        assert call_tracker["step2_calls"] == 2
+        assert result.at[0, "f2"] == "cached_val_done"
+        assert result.at[1, "f2"] == "cached_val2_done"
+
 
 # -- stable data_identifier --------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Wires `expected_total_rows`, `expected_fields`, and `expected_steps` into the `CheckpointManager.load()` call in `Enricher.run_async`, activating the strict validation block that was previously dead code for all callers.
- Removes the now-redundant ad-hoc row-count and fields_dict checks that lived in `enricher.py` (shallower than the strict path in `checkpoint.py:200-228`).
- Uses `self.pipeline.step_names` (the ordered execution-level list on `Pipeline`) to pass step names.

## Tests added

1. **Renamed step discards checkpoint** — saves checkpoint with step `a`, pipeline has `a_v2`; verifies discard + fresh re-run.
2. **Row count mismatch discards checkpoint** — checkpoint has 3 rows, run with 2; verifies fresh re-run.
3. **Field mismatch discards checkpoint** — checkpoint has different field keys; verifies fresh re-run.
4. **Matching shape resumes correctly** — existing happy-path, confirmed still passing.

## Test plan

- [x] `uv run pytest tests/test_enricher.py -q` — 22 passed
- [x] `uv run ruff check accrue/ tests/` — clean
- [x] `uv run ruff format --check accrue/ tests/` — clean

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)