### PR TITLE
fix(pipeline): log sibling exceptions in level-gather before raising primary

### DIFF
--- a/accrue/pipeline/pipeline.py
+++ b/accrue/pipeline/pipeline.py
@@ -641,9 +641,17 @@ class Pipeline:
                 gathered = await asyncio.gather(*level_coros, return_exceptions=True)
 
                 # Surface the first exception (after siblings have been awaited)
-                first_exc = next((r for r in gathered if isinstance(r, BaseException)), None)
-                if first_exc is not None:
-                    raise first_exc
+                exceptions = [r for r in gathered if isinstance(r, BaseException)]
+                if exceptions:
+                    if len(exceptions) > 1:
+                        for extra in exceptions[1:]:
+                            logger.warning(
+                                "Sibling step in same level also raised "
+                                "(suppressed by primary): %s: %s",
+                                type(extra).__name__,
+                                extra,
+                            )
+                    raise exceptions[0]
 
                 step_results_list = gathered
 

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -250,6 +250,59 @@ class TestLevelGatherSiblingsAwaited:
         assert step_tasks == [], f"Orphaned step tasks found: {step_tasks}"
 
 
+class TestSiblingExceptionLogging:
+    @pytest.mark.asyncio
+    async def test_sibling_exceptions_both_logged(self, caplog):
+        """Two parallel steps both raise; second exception is logged at WARNING."""
+        import logging
+
+        async def fail_a(ctx):
+            raise ValueError("step_a blew up")
+
+        async def fail_b(ctx):
+            raise RuntimeError("step_b blew up")
+
+        p = Pipeline(
+            [
+                FunctionStep("step_a", fn=fail_a, fields=["a"]),
+                FunctionStep("step_b", fn=fail_b, fields=["b"]),
+            ]
+        )
+        rows = [{"x": 1}]
+        config = EnrichmentConfig(on_error="raise", max_workers=2)
+
+        with caplog.at_level(logging.WARNING, logger="accrue.pipeline.pipeline"):
+            with pytest.raises((ValueError, RuntimeError)):
+                await p.execute(rows, all_fields={}, config=config)
+
+        # One of the two exceptions is logged as a sibling warning
+        sibling_warnings = [
+            r for r in caplog.records if "Sibling step in same level also raised" in r.message
+        ]
+        assert len(sibling_warnings) == 1
+        # The warning mentions the suppressed exception type
+        msg = sibling_warnings[0].message
+        assert "ValueError" in msg or "RuntimeError" in msg
+
+    @pytest.mark.asyncio
+    async def test_single_failure_no_sibling_warning(self, caplog):
+        """Single step failure: no sibling-suppressed warning emitted."""
+        import logging
+
+        p = Pipeline([_failing_step("s", ["f"], fail_indices={0})])
+        rows = [{"__idx": 0}]
+        config = EnrichmentConfig(on_error="raise", max_workers=1)
+
+        with caplog.at_level(logging.WARNING, logger="accrue.pipeline.pipeline"):
+            with pytest.raises(Exception):
+                await p.execute(rows, all_fields={}, config=config)
+
+        sibling_warnings = [
+            r for r in caplog.records if "Sibling step in same level also raised" in r.message
+        ]
+        assert sibling_warnings == []
+
+
 class TestOnErrorContinueRegression:
     @pytest.mark.asyncio
     async def test_continue_mode_collects_errors_and_succeeds(self):


### PR DESCRIPTION
## Summary

- Collect all exceptions from `asyncio.gather` in the level-gather loop instead of just the first
- Log each non-primary exception at `WARNING` before raising the first, so silently-dropped sibling failures are now visible
- Two focused tests added to `tests/test_error_handling.py`: one asserting the WARNING is emitted for the second exception, one regression-guarding the single-failure path

Closes #61

## Test plan

- [ ] `pytest tests/test_error_handling.py -x -q` — all 14 pass
- [ ] `ruff check accrue/ tests/` — no errors
- [ ] `ruff format --check accrue/ tests/` — 67 files already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)