### PR TITLE
fix(pipeline-batch): cancel earlier chunks on submit failure; catch CancelledError in poll loop

### DIFF
--- a/accrue/pipeline/pipeline.py
+++ b/accrue/pipeline/pipeline.py
@@ -1185,13 +1185,24 @@ class Pipeline:
             )
 
         batch_ids: list[str] = []
-        for chunk in chunks:
-            bid = await client.submit_batch(
-                chunk,
-                metadata={"step": step.name, "pipeline": "accrue"},
-            )
-            batch_ids.append(bid)
-            logger.info("Step '%s': submitted batch %s (%d requests)", step.name, bid, len(chunk))
+        try:
+            for chunk in chunks:
+                bid = await client.submit_batch(
+                    chunk,
+                    metadata={"step": step.name, "pipeline": "accrue"},
+                )
+                batch_ids.append(bid)
+                logger.info(
+                    "Step '%s': submitted batch %s (%d requests)", step.name, bid, len(chunk)
+                )
+        except Exception:
+            # Best-effort cancel of already-submitted batches before propagating
+            if batch_ids:
+                await asyncio.gather(
+                    *(client.cancel_batch(bid) for bid in batch_ids),
+                    return_exceptions=True,
+                )
+            raise
 
         # ── Phase 4: Poll (with KeyboardInterrupt handling) ────────────
         from ..steps.providers.base import BatchResult
@@ -1213,7 +1224,7 @@ class Pipeline:
                 all_responses.update(batch_result.responses)
                 all_failed.extend(batch_result.failed_ids)
                 all_errors_map.update(batch_result.errors)
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, asyncio.CancelledError):
             logger.warning(
                 "KeyboardInterrupt — cancelling %d batch(es): %s",
                 len(batch_ids),

--- a/tests/test_batch_pipeline.py
+++ b/tests/test_batch_pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -453,3 +454,73 @@ class TestBatchKeyboardInterrupt:
 
         # The batch was submitted before the poll failure
         client.submit_batch.assert_called_once()
+
+
+# -- CancelledError and submit-failure cleanup ---------------------------------
+
+
+class TestBatchCancellationCleanup:
+    @pytest.mark.asyncio
+    async def test_cancelled_error_during_poll_cancels_all_batches(self):
+        """asyncio.CancelledError during poll must cancel every submitted batch_id."""
+        client = _make_batch_client()
+        client.poll_batch = AsyncMock(side_effect=asyncio.CancelledError())
+        client.cancel_batch = AsyncMock()
+
+        step = _make_batch_step(client=client)
+        pipeline = Pipeline([step])
+
+        with pytest.raises((asyncio.CancelledError, BaseException)):
+            await pipeline.run_async([{"company": "Acme"}])
+
+        client.submit_batch.assert_called_once()
+        client.cancel_batch.assert_called_once_with("batch_test_123")
+
+    @pytest.mark.asyncio
+    async def test_submit_failure_cancels_earlier_chunks(self):
+        """If submit_batch raises on the second chunk, the first chunk must be cancelled."""
+        submit_call_count = 0
+
+        async def submit_side_effect(requests, metadata=None):
+            nonlocal submit_call_count
+            submit_call_count += 1
+            if submit_call_count == 1:
+                return "batch_chunk_1"
+            raise RuntimeError("API error on second submit")
+
+        client = AsyncMock(spec=["complete", "submit_batch", "poll_batch", "cancel_batch"])
+        client.complete = AsyncMock(return_value=_mock_llm_response('{"market_size": "$1B"}'))
+        client.submit_batch = submit_side_effect
+        client.poll_batch = AsyncMock()
+        client.cancel_batch = AsyncMock()
+
+        step = _make_batch_step(client=client)
+        pipeline = Pipeline([step])
+        config = EnrichmentConfig(batch_max_requests=1)
+
+        # Two rows with max_requests=1 produces 2 chunks; second submit will fail
+        with pytest.raises(RuntimeError, match="API error"):
+            await pipeline.run_async([{"company": "Acme"}, {"company": "Beta"}], config=config)
+
+        # First chunk was submitted and must be cancelled
+        client.cancel_batch.assert_called_once_with("batch_chunk_1")
+        # poll_batch should never be reached
+        client.poll_batch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_happy_path_no_cancel_calls(self):
+        """Normal batch execution must not call cancel_batch."""
+        client = _make_batch_client(
+            responses={
+                "row-0": '{"market_size": "$5B"}',
+                "row-1": '{"market_size": "$3B"}',
+            }
+        )
+        step = _make_batch_step(client=client)
+        pipeline = Pipeline([step])
+
+        result = await pipeline.run_async([{"company": "Acme"}, {"company": "Beta"}])
+
+        client.cancel_batch.assert_not_called()
+        assert result.data[0]["market_size"] == "$5B"
+        assert result.data[1]["market_size"] == "$3B"


### PR DESCRIPTION
## Summary

- Wraps the `submit_batch` loop in `try/except` so that if any chunk's submission fails, all already-submitted batches are cancelled via `asyncio.gather(..., return_exceptions=True)` before re-raising — preventing orphaned billable batches
- Fixes poll-loop exception handler to catch `(KeyboardInterrupt, asyncio.CancelledError)` instead of only `KeyboardInterrupt`, matching the existing realtime path

## Tests added

Three new tests in `TestBatchCancellationCleanup`:
1. `test_cancelled_error_during_poll_cancels_all_batches` — `CancelledError` from `poll_batch` triggers `cancel_batch`
2. `test_submit_failure_cancels_earlier_chunks` — second `submit_batch` failure cancels the already-submitted first chunk
3. `test_happy_path_no_cancel_calls` — normal execution never calls `cancel_batch`

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)