### PR TITLE
fix(anthropic): dedup grounding+schema warning to once per client instance (#64)

### DIFF
--- a/accrue/steps/providers/anthropic.py
+++ b/accrue/steps/providers/anthropic.py
@@ -38,6 +38,7 @@ class AnthropicClient:
         self._api_key = api_key
         self._http_client = http_client
         self._client: Any = None
+        self._warned_grounding_schema: bool = False
 
     def _get_client(self) -> Any:
         if self._client is None:
@@ -109,12 +110,14 @@ class AnthropicClient:
         # json_schema → constrained decoding; json_object → no equivalent, skip
         # IMPORTANT: output_config.format is incompatible with web search citations
         if anthropic_tools and response_format and response_format.get("type") == "json_schema":
-            logger.warning(
-                "Anthropic grounding (web search tools) is incompatible with strict "
-                "structured outputs; structured output schema will not be enforced for "
-                "this request. Consider running a separate non-grounded LLMStep over "
-                "the grounded context, or disable grounding for this step."
-            )
+            if not self._warned_grounding_schema:
+                logger.warning(
+                    "Anthropic grounding (web search tools) is incompatible with strict "
+                    "structured outputs; structured output schema will not be enforced for "
+                    "this request. Consider running a separate non-grounded LLMStep over "
+                    "the grounded context, or disable grounding for this step."
+                )
+                self._warned_grounding_schema = True
         if not anthropic_tools and response_format and response_format.get("type") == "json_schema":
             inner = response_format.get("json_schema", {})
             schema = inner.get("schema", {})

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -890,6 +890,127 @@ class TestAnthropicClient:
         assert result.citations[0].title == "Example Article"
         assert result.citations[0].snippet == "The answer is 42."
 
+    @pytest.mark.asyncio
+    async def test_grounding_schema_warning_fires_once_per_client(self, caplog):
+        """Warning fires exactly once per client across N complete() calls."""
+        self._install_mock_anthropic()
+        from accrue.steps.providers.anthropic import AnthropicClient
+
+        schema = {"type": "object", "properties": {"f1": {"type": "string"}}}
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {"name": "test", "schema": schema, "strict": True},
+        }
+        mock_response = SimpleNamespace(
+            content=[SimpleNamespace(text='{"f1": "val"}', type="text", citations=None)],
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        )
+        mock_inner = MagicMock()
+        mock_inner.messages.create = AsyncMock(return_value=mock_response)
+
+        client = AnthropicClient(api_key="test")
+        client._client = mock_inner
+
+        with caplog.at_level(logging.WARNING, logger="accrue.steps.providers.anthropic"):
+            for _ in range(5):
+                await client.complete(
+                    messages=[{"role": "user", "content": "hi"}],
+                    model="claude-sonnet-4-5-20250929",
+                    temperature=0.2,
+                    max_tokens=1000,
+                    response_format=response_format,
+                    tools=[{"type": "web_search"}],
+                )
+
+        warning_records = [
+            r
+            for r in caplog.records
+            if "structured output schema will not be enforced" in r.message
+        ]
+        assert len(warning_records) == 1
+
+    @pytest.mark.asyncio
+    async def test_grounding_schema_warning_fires_on_first_call(self, caplog):
+        """Warning fires on first call when grounding+schema both set (regression for #57)."""
+        self._install_mock_anthropic()
+        from accrue.steps.providers.anthropic import AnthropicClient
+
+        schema = {"type": "object", "properties": {"f1": {"type": "string"}}}
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {"name": "test", "schema": schema, "strict": True},
+        }
+        mock_response = SimpleNamespace(
+            content=[SimpleNamespace(text='{"f1": "val"}', type="text", citations=None)],
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        )
+        mock_inner = MagicMock()
+        mock_inner.messages.create = AsyncMock(return_value=mock_response)
+
+        client = AnthropicClient(api_key="test")
+        client._client = mock_inner
+
+        with caplog.at_level(logging.WARNING, logger="accrue.steps.providers.anthropic"):
+            await client.complete(
+                messages=[{"role": "user", "content": "hi"}],
+                model="claude-sonnet-4-5-20250929",
+                temperature=0.2,
+                max_tokens=1000,
+                response_format=response_format,
+                tools=[{"type": "web_search"}],
+            )
+
+        assert "structured output schema will not be enforced" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_grounding_schema_warning_fires_for_fresh_client(self, caplog):
+        """A second AnthropicClient instance emits its own warning (cache is per-instance)."""
+        self._install_mock_anthropic()
+        from accrue.steps.providers.anthropic import AnthropicClient
+
+        schema = {"type": "object", "properties": {"f1": {"type": "string"}}}
+        response_format = {
+            "type": "json_schema",
+            "json_schema": {"name": "test", "schema": schema, "strict": True},
+        }
+        mock_response = SimpleNamespace(
+            content=[SimpleNamespace(text='{"f1": "val"}', type="text", citations=None)],
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        )
+        mock_inner = MagicMock()
+        mock_inner.messages.create = AsyncMock(return_value=mock_response)
+
+        # First client — exhaust its warning
+        client_a = AnthropicClient(api_key="test")
+        client_a._client = mock_inner
+        with caplog.at_level(logging.WARNING, logger="accrue.steps.providers.anthropic"):
+            for _ in range(3):
+                await client_a.complete(
+                    messages=[{"role": "user", "content": "hi"}],
+                    model="claude-sonnet-4-5-20250929",
+                    temperature=0.2,
+                    max_tokens=1000,
+                    response_format=response_format,
+                    tools=[{"type": "web_search"}],
+                )
+
+        caplog.clear()
+
+        # Second client — must still fire its own warning
+        client_b = AnthropicClient(api_key="test")
+        client_b._client = mock_inner
+        with caplog.at_level(logging.WARNING, logger="accrue.steps.providers.anthropic"):
+            await client_b.complete(
+                messages=[{"role": "user", "content": "hi"}],
+                model="claude-sonnet-4-5-20250929",
+                temperature=0.2,
+                max_tokens=1000,
+                response_format=response_format,
+                tools=[{"type": "web_search"}],
+            )
+
+        assert "structured output schema will not be enforced" in caplog.text
+
 
 # -- GoogleClient -----------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- The `logger.warning()` for grounding+schema incompatibility was emitted inside `complete()`, causing a 10,000-row batch run to emit 10,000 identical warnings.
- Added `_warned_grounding_schema: bool = False` to `AnthropicClient.__init__` and guard the warning with it, setting `True` after the first emission.
- Cache is per-instance, so a fresh `AnthropicClient` still gets its own first warning.

## Changes
- `accrue/steps/providers/anthropic.py`: initialize flag in `__init__`; wrap `logger.warning` with guard
- `tests/test_providers.py`: 3 new tests covering once-per-client dedup, fires on first call (regression for #57), and fresh client gets fresh warning

## Testing
- 585 tests pass (`pytest -x -q`)
- `ruff check` + `ruff format --check` both clean

## Checklist
- [x] Lint passes
- [x] Tests pass
- [x] No evals needed (internal logging behavior, no behavioral output change)
- [x] Labels copied from source issue + AI-attribution applied
- [x] Self-reviewed
- [x] No architectural decision required (instance flag, minimal change)

Closes #64