### PR TITLE
fix(google): populate status_code on adapter exceptions so 5xx/timeout are retryable (#65)

### DIFF
--- a/accrue/steps/providers/google.py
+++ b/accrue/steps/providers/google.py
@@ -12,6 +12,14 @@ from .base import LLMAPIError, LLMResponse
 
 logger = logging.getLogger(__name__)
 
+# Lazily resolved; populated once on first exception classification.
+# google-api-core ships with google-genai so it will normally be present,
+# but we don't declare it as a hard dependency.
+try:
+    import google.api_core.exceptions as _gax_exc
+except ImportError:  # pragma: no cover
+    _gax_exc = None  # type: ignore[assignment]
+
 
 class GoogleClient:
     """Adapter for Google's Gemini models.
@@ -109,20 +117,7 @@ class GoogleClient:
                 config=types.GenerateContentConfig(**config),
             )
         except Exception as exc:
-            # Google SDK doesn't have typed error classes as clean as OpenAI/Anthropic
-            exc_str = str(exc).lower()
-            if "429" in exc_str or "rate" in exc_str:
-                raise LLMAPIError(
-                    f"Google rate limit for model '{model}': {exc}",
-                    status_code=429,
-                    is_rate_limit=True,
-                ) from exc
-            if "timeout" in exc_str:
-                raise LLMAPIError(
-                    f"Google timeout for model '{model}': {exc}",
-                    status_code=408,
-                ) from exc
-            raise LLMAPIError(f"Google API error for model '{model}': {exc}") from exc
+            raise _classify_google_exc(exc, model) from exc
 
         content = response.text or ""
 
@@ -146,6 +141,78 @@ class GoogleClient:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _classify_google_exc(exc: Exception, model: str) -> LLMAPIError:
+    """Classify a Google SDK exception into a typed LLMAPIError.
+
+    Tries typed ``google.api_core.exceptions`` first (Option A); falls back to
+    substring heuristics (Option B) for unknown exception types or when the
+    ``google-api-core`` package is unavailable.
+    """
+    # Option A — typed classification via google.api_core.exceptions
+    if _gax_exc is not None:
+        if isinstance(exc, _gax_exc.ResourceExhausted):
+            return LLMAPIError(
+                f"Google rate limit for model '{model}': {exc}",
+                is_rate_limit=True,
+                status_code=429,
+            )
+        if isinstance(
+            exc,
+            (
+                _gax_exc.ServiceUnavailable,
+                getattr(_gax_exc, "InternalServerError", type(None)),
+                getattr(_gax_exc, "BadGateway", type(None)),
+            ),
+        ):
+            return LLMAPIError(
+                f"Google server error for model '{model}': {exc}",
+                status_code=503,
+            )
+        if isinstance(exc, _gax_exc.DeadlineExceeded):
+            return LLMAPIError(
+                f"Google deadline exceeded for model '{model}': {exc}",
+                retryable=True,
+            )
+        if isinstance(
+            exc,
+            (
+                getattr(_gax_exc, "InvalidArgument", type(None)),
+                getattr(_gax_exc, "PermissionDenied", type(None)),
+                getattr(_gax_exc, "NotFound", type(None)),
+            ),
+        ):
+            return LLMAPIError(
+                f"Google API error for model '{model}': {exc}",
+                status_code=400,
+            )
+
+    # Option B — substring heuristics (fallback for unknown types)
+    exc_str = str(exc).lower()
+    if "429" in exc_str or "resource exhausted" in exc_str or "rate" in exc_str:
+        return LLMAPIError(
+            f"Google rate limit for model '{model}': {exc}",
+            is_rate_limit=True,
+            status_code=429,
+        )
+    for code, marker in [
+        (500, "internal server error"),
+        (502, "bad gateway"),
+        (503, "service unavailable"),
+        (504, "gateway timeout"),
+    ]:
+        if marker in exc_str:
+            return LLMAPIError(
+                f"Google server error for model '{model}': {exc}",
+                status_code=code,
+            )
+    if "deadline exceeded" in exc_str or "timeout" in exc_str:
+        return LLMAPIError(
+            f"Google timeout for model '{model}': {exc}",
+            retryable=True,
+        )
+    return LLMAPIError(f"Google API error for model '{model}': {exc}")
 
 
 def _translate_tools(tools: list[dict[str, Any]], types: Any) -> list[Any]:

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1180,3 +1180,146 @@ class TestGoogleClient:
             )
 
         assert "allowed_domains is not supported" in caplog.text
+
+    # -- Retry classification (regression for #65) --------------------------
+
+    @pytest.mark.asyncio
+    async def test_5xx_is_retryable(self):
+        """503 Service Unavailable from Gemini → LLMAPIError.retryable True."""
+        import sys
+
+        self._install_mock_google()
+        # Ensure google.api_core is NOT present so we exercise the substring path
+        sys.modules.pop("google.api_core", None)
+        sys.modules.pop("google.api_core.exceptions", None)
+        # Reload the google module to pick up the patched sys.modules
+        import importlib
+
+        import accrue.steps.providers.google as _google_mod
+
+        importlib.reload(_google_mod)
+
+        from accrue.steps.providers.google import GoogleClient
+
+        mock_client = MagicMock()
+        mock_client.aio.models.generate_content = AsyncMock(
+            side_effect=Exception("503 Service Unavailable")
+        )
+
+        client = GoogleClient(api_key="test")
+        client._client = mock_client
+
+        with pytest.raises(LLMAPIError) as exc_info:
+            await client.complete(
+                messages=[{"role": "user", "content": "hi"}],
+                model="gemini-2.5-flash",
+                temperature=0.0,
+                max_tokens=10,
+            )
+
+        assert exc_info.value.retryable is True
+        assert exc_info.value.status_code == 503
+
+    @pytest.mark.asyncio
+    async def test_timeout_is_retryable(self):
+        """Deadline exceeded / timeout from Gemini → LLMAPIError.retryable True."""
+        import sys
+
+        self._install_mock_google()
+        sys.modules.pop("google.api_core", None)
+        sys.modules.pop("google.api_core.exceptions", None)
+        import importlib
+
+        import accrue.steps.providers.google as _google_mod
+
+        importlib.reload(_google_mod)
+
+        from accrue.steps.providers.google import GoogleClient
+
+        mock_client = MagicMock()
+        mock_client.aio.models.generate_content = AsyncMock(
+            side_effect=Exception("Deadline exceeded waiting for response")
+        )
+
+        client = GoogleClient(api_key="test")
+        client._client = mock_client
+
+        with pytest.raises(LLMAPIError) as exc_info:
+            await client.complete(
+                messages=[{"role": "user", "content": "hi"}],
+                model="gemini-2.5-flash",
+                temperature=0.0,
+                max_tokens=10,
+            )
+
+        assert exc_info.value.retryable is True
+
+    @pytest.mark.asyncio
+    async def test_400_invalid_argument_not_retryable(self):
+        """400 / invalid argument from Gemini → LLMAPIError.retryable False."""
+        import sys
+
+        self._install_mock_google()
+        sys.modules.pop("google.api_core", None)
+        sys.modules.pop("google.api_core.exceptions", None)
+        import importlib
+
+        import accrue.steps.providers.google as _google_mod
+
+        importlib.reload(_google_mod)
+
+        from accrue.steps.providers.google import GoogleClient
+
+        mock_client = MagicMock()
+        mock_client.aio.models.generate_content = AsyncMock(
+            side_effect=Exception("400 Bad Request: invalid argument in prompt")
+        )
+
+        client = GoogleClient(api_key="test")
+        client._client = mock_client
+
+        with pytest.raises(LLMAPIError) as exc_info:
+            await client.complete(
+                messages=[{"role": "user", "content": "hi"}],
+                model="gemini-2.5-flash",
+                temperature=0.0,
+                max_tokens=10,
+            )
+
+        assert exc_info.value.retryable is False
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_429_is_retryable(self):
+        """429 / resource exhausted from Gemini → LLMAPIError.retryable True (regression guard)."""
+        import sys
+
+        self._install_mock_google()
+        sys.modules.pop("google.api_core", None)
+        sys.modules.pop("google.api_core.exceptions", None)
+        import importlib
+
+        import accrue.steps.providers.google as _google_mod
+
+        importlib.reload(_google_mod)
+
+        from accrue.steps.providers.google import GoogleClient
+
+        mock_client = MagicMock()
+        mock_client.aio.models.generate_content = AsyncMock(
+            side_effect=Exception("429 Resource Exhausted: quota exceeded")
+        )
+
+        client = GoogleClient(api_key="test")
+        client._client = mock_client
+
+        with pytest.raises(LLMAPIError) as exc_info:
+            await client.complete(
+                messages=[{"role": "user", "content": "hi"}],
+                model="gemini-2.5-flash",
+                temperature=0.0,
+                max_tokens=10,
+            )
+
+        assert exc_info.value.retryable is True
+        assert exc_info.value.is_rate_limit is True
+        assert exc_info.value.status_code == 429


### PR DESCRIPTION
## Summary
After PR #56 narrowed the retry allowlist and disabled native SDK retry (`max_retries=0`), the Google adapter regressed: transient 5xx errors from Gemini were no longer retried because the catch-all `LLMAPIError` was raised without `status_code`, making `retryable` evaluate to `False`.

## Changes
- Add `_classify_google_exc()` helper in `accrue/steps/providers/google.py` that maps Google SDK exceptions to typed `LLMAPIError` with correct `status_code`/`is_rate_limit`/`retryable`
- Option A: typed classification via `google.api_core.exceptions` (`ResourceExhausted`→429, `ServiceUnavailable`/`InternalServerError`/`BadGateway`→503, `DeadlineExceeded`→retryable=True, `InvalidArgument`/`PermissionDenied`/`NotFound`→400 non-retryable)
- Option B: substring heuristics fallback for unknown types or when `google-api-core` is unavailable
- Lazy module-level import of `google.api_core.exceptions` — no new hard dependency

## Testing
- 4 focused regression tests added to `tests/test_providers.py`:
  1. 503 Service Unavailable → `retryable=True`
  2. Deadline exceeded → `retryable=True`
  3. 400 invalid argument → `retryable=False`
  4. 429 resource exhausted → `retryable=True`, `is_rate_limit=True` (regression guard)
- Full test suite: 586 passed
- Lint: `ruff check` + `ruff format --check` both clean

## Checklist
- [x] Lint passes
- [x] Tests pass
- [x] No evals framework — skip
- [x] Labels copied from source issue applied
- [x] Self-reviewed
- [x] Trivial fix (<3 files) — no ADR needed

Closes #65