### PR TITLE
fix(exceptions): redact API keys and Bearer tokens from RowError __str__ (#75)

### DIFF
--- a/accrue/core/exceptions.py
+++ b/accrue/core/exceptions.py
@@ -7,8 +7,23 @@ with helpful error messages and context.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Any
+
+_SECRET_PATTERNS = [
+    re.compile(r"sk-[A-Za-z0-9_-]{20,}"),
+    re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._\-]+"),
+    re.compile(r"(?i)authorization\s*:\s*\S+"),
+    re.compile(r"(?i)api[_-]?key\s*[:=]\s*\S+"),
+]
+
+
+def _sanitize_secrets(s: str) -> str:
+    """Replace known secret patterns with a redaction marker."""
+    for pat in _SECRET_PATTERNS:
+        s = pat.sub("***REDACTED***", s)
+    return s
 
 
 class EnrichmentError(Exception):
@@ -95,7 +110,7 @@ class RowError:
             self.error_type = type(self.error).__name__
 
     def __str__(self) -> str:
-        return (
+        return _sanitize_secrets(
             f"RowError(row={self.row_index}, step='{self.step_name}', "
             f"{self.error_type}: {self.error})"
         )

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -147,6 +147,44 @@ class TestRowError:
         err = RowError(row_index=0, step_name="s", error=StepError("fail"))
         assert err.error_type == "StepError"
 
+    # -- secret sanitization --------------------------------------------------
+
+    def test_api_key_sk_redacted(self):
+        """sk-... API key in exception message is redacted from __str__."""
+        key = "sk-abc123def456ghi789jklmnop"
+        err = RowError(row_index=0, step_name="s", error=ValueError(f"auth failed: {key}"))
+        s = str(err)
+        assert "***REDACTED***" in s
+        assert key not in s
+
+    def test_bearer_token_redacted(self):
+        """Bearer token in exception message is redacted from __str__."""
+        err = RowError(
+            row_index=1,
+            step_name="s",
+            error=ValueError("401: Authorization: Bearer eyJh.abc.def"),
+        )
+        s = str(err)
+        assert "***REDACTED***" in s
+        assert "eyJh.abc.def" not in s
+
+    def test_api_key_param_redacted(self):
+        """api_key=... in exception message is redacted from __str__."""
+        err = RowError(
+            row_index=2,
+            step_name="s",
+            error=ValueError("api_key=sk-xyz failed"),
+        )
+        s = str(err)
+        assert "***REDACTED***" in s
+        assert "sk-xyz" not in s
+
+    def test_plain_error_unchanged(self):
+        """Plain English error messages pass through unsanitized."""
+        msg = "missing required field 'company'"
+        err = RowError(row_index=3, step_name="s", error=ValueError(msg))
+        assert msg in str(err)
+
 
 # -- Enricher integration with errors ----------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds module-level regex patterns to match common secret formats (sk-* API keys, Bearer tokens, Authorization headers, api_key= params)
- Applies `_sanitize_secrets()` in `RowError.__str__` so error strings persisted to checkpoint files never contain raw credentials
- Fixes secret leakage that occurs when `on_error="continue"` and provider exceptions include API keys in their messages

## Changes
- `accrue/core/exceptions.py`: Added `_SECRET_PATTERNS`, `_sanitize_secrets()`, applied in `RowError.__str__`
- `tests/test_error_handling.py`: Added 4 tests — sk-* redaction, Bearer token redaction, api_key= redaction, and regression for plain messages

## Testing
- 4 new unit tests covering all redaction patterns and the plain-message regression
- All 14 tests in `test_error_handling.py` pass
- `ruff check` and `ruff format --check` both clean

## Checklist
- [x] Lint passes
- [x] Tests pass
- [x] Relevant evals pass — no evals framework present, internal-only fix with no LLM behavior change
- [x] Labels copied from source issue applied
- [x] Self-reviewed
- [x] Compounding loop run — no novel findings
- [x] ADR not needed — no architectural decision, targeted security fix

Closes #75