### PR TITLE
fix(config): XDG-respecting cache_dir + checkpoint_dir defaults; 0600 file perms

### DIFF
--- a/accrue/core/cache.py
+++ b/accrue/core/cache.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import sqlite3
 import threading
 import time
@@ -54,6 +55,11 @@ class CacheManager:
             db_path = self._cache_dir / "cache.db"
 
             conn = sqlite3.connect(str(db_path), check_same_thread=False)
+            if os.name == "posix":
+                try:
+                    os.chmod(db_path, 0o600)
+                except (OSError, NotImplementedError):
+                    pass
             conn.execute("PRAGMA journal_mode=WAL")
             conn.execute("PRAGMA busy_timeout=5000")
             conn.execute("PRAGMA synchronous=NORMAL")

--- a/accrue/core/checkpoint.py
+++ b/accrue/core/checkpoint.py
@@ -190,6 +190,11 @@ class CheckpointManager:
                     f.flush()
                     os.fsync(f.fileno())
                 os.replace(tmp_path, path)
+                if os.name == "posix":
+                    try:
+                        os.chmod(path, 0o600)
+                    except (OSError, NotImplementedError):
+                        pass
             except Exception:
                 tmp_path.unlink(missing_ok=True)
                 raise

--- a/accrue/core/config.py
+++ b/accrue/core/config.py
@@ -7,7 +7,21 @@ For Tier 1 accounts, reduce max_workers to 5-10.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+def _default_cache_dir() -> str:
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".cache"
+    return str(base / "accrue")
+
+
+def _default_checkpoint_dir() -> str:
+    xdg = os.environ.get("XDG_STATE_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".local" / "state"
+    return str(base / "accrue")
 
 
 @dataclass
@@ -64,8 +78,9 @@ class EnrichmentConfig:
     enable_checkpointing: bool = False
     """Save results after each step completes for crash recovery."""
 
-    checkpoint_dir: str | None = None
-    """Directory for checkpoint files. None = temp directory."""
+    checkpoint_dir: str = field(default_factory=_default_checkpoint_dir)
+    """Directory for checkpoint files. Defaults to XDG_STATE_HOME/accrue or ~/.local/state/accrue.
+    """
 
     auto_resume: bool = True
     """Automatically resume from checkpoint on re-run."""
@@ -83,8 +98,8 @@ class EnrichmentConfig:
     cache_ttl: int = 3600
     """Cache time-to-live in seconds."""
 
-    cache_dir: str = ".accrue"
-    """Directory for cache.db."""
+    cache_dir: str = field(default_factory=_default_cache_dir)
+    """Directory for cache.db. Defaults to XDG_CACHE_HOME/accrue or ~/.cache/accrue."""
 
     checkpoint_interval: int = 0
     """Save partial step progress every N rows. 0 = disabled."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,25 @@ def _isolate_cache_dir(tmp_path, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_xdg_dirs(tmp_path, monkeypatch):
+    """Scope XDG-backed defaults (cache_dir, checkpoint_dir) to a per-test tmp dir.
+
+    ``EnrichmentConfig`` defaults ``cache_dir`` to ``$XDG_CACHE_HOME/accrue`` and
+    ``checkpoint_dir`` to ``$XDG_STATE_HOME/accrue`` via ``default_factory``.
+    Without isolation, every test sharing the developer's real XDG dirs would see
+    cache + checkpoint state bleed between runs — causing spurious cache hits and
+    ``complete``-mock-call-count == 0 failures.
+
+    Tests that explicitly pass ``cache_dir=`` / ``checkpoint_dir=`` are unaffected.
+    The ``TestXdg*`` classes in ``test_config.py`` / ``test_checkpoint.py`` set
+    these vars themselves inside the test body, which overrides this fixture's
+    values for that test (monkeypatch is stack-scoped).
+    """
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "xdg-cache"))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "xdg-state"))
+
+
+@pytest.fixture(autouse=True)
 def _scrub_provider_env_vars(monkeypatch):
     """Remove real provider keys and substitute a dummy so non-empty checks pass.
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import concurrent.futures
+import os
 import sqlite3
+import sys
 import threading
 import time
 from unittest.mock import patch
+
+import pytest
 
 from accrue.core.cache import (
     CacheManager,
@@ -14,6 +18,7 @@ from accrue.core.cache import (
     canonical_json,
     compute_cache_key,
 )
+from accrue.core.config import EnrichmentConfig
 
 # ---------------------------------------------------------------------------
 # CacheManager
@@ -411,3 +416,39 @@ class TestComputeStepCacheKey:
         # FunctionStep has no model — confirm it takes the function path
         assert not hasattr(step, "max_tokens")
         assert not hasattr(step, "provider_kwargs")
+
+
+# ---------------------------------------------------------------------------
+# XDG defaults + 0o600 permissions
+# ---------------------------------------------------------------------------
+
+
+class TestXdgCacheDirDefault:
+    def test_xdg_cache_home_respected(self, monkeypatch, tmp_path):
+        """XDG_CACHE_HOME is used as the base for cache_dir."""
+        xdg_cache = str(tmp_path / "xdg_cache")
+        monkeypatch.setenv("XDG_CACHE_HOME", xdg_cache)
+        config = EnrichmentConfig()
+        assert config.cache_dir == os.path.join(xdg_cache, "accrue")
+
+    def test_fallback_to_home_cache_when_xdg_unset(self, monkeypatch):
+        """Falls back to ~/.cache/accrue when XDG_CACHE_HOME is unset."""
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        config = EnrichmentConfig()
+        expected = os.path.join(os.path.expanduser("~"), ".cache", "accrue")
+        assert config.cache_dir == expected
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only chmod")
+    def test_cache_db_has_0o600_permissions(self, tmp_path):
+        """cache.db is created with 0o600 permissions."""
+        mgr = CacheManager(cache_dir=str(tmp_path), ttl=3600)
+        mgr.set("k", "step", {"v": 1})
+        stat = (tmp_path / "cache.db").stat()
+        assert stat.st_mode & 0o777 == 0o600
+        mgr.close()
+
+    def test_custom_cache_dir_constructor_arg_still_works(self, tmp_path):
+        """Regression: explicit cache_dir= overrides the XDG default."""
+        custom = str(tmp_path / "custom_cache")
+        config = EnrichmentConfig(cache_dir=custom)
+        assert config.cache_dir == custom

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -2,6 +2,8 @@
 
 import json
 import logging
+import os
+import sys
 from datetime import datetime
 from decimal import Decimal
 from pathlib import Path
@@ -560,3 +562,47 @@ class TestLegacyCheckpointDetection:
 
         assert result is None, "Legacy checkpoint must be discarded (return None)"
         assert "Legacy checkpoint format" in caplog.text, "A WARNING must be logged"
+
+
+# -- XDG defaults + 0o600 permissions ----------------------------------------
+
+
+class TestXdgCheckpointDirDefault:
+    def test_xdg_state_home_respected(self, monkeypatch, tmp_path):
+        """XDG_STATE_HOME is used as the base for checkpoint_dir."""
+        xdg_state = str(tmp_path / "xdg_state")
+        monkeypatch.setenv("XDG_STATE_HOME", xdg_state)
+        config = EnrichmentConfig()
+        assert config.checkpoint_dir == os.path.join(xdg_state, "accrue")
+
+    def test_fallback_to_local_state_when_xdg_unset(self, monkeypatch):
+        """Falls back to ~/.local/state/accrue when XDG_STATE_HOME is unset."""
+        monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+        config = EnrichmentConfig()
+        expected = os.path.join(os.path.expanduser("~"), ".local", "state", "accrue")
+        assert config.checkpoint_dir == expected
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only chmod")
+    def test_checkpoint_file_has_0o600_permissions(self, tmp_path):
+        """Checkpoint files are written with 0o600 permissions."""
+        mgr = _make_mgr(tmp_path)
+        mgr.save_step(
+            data_identifier="data",
+            category="cat",
+            step_name="s",
+            step_row_results=[{"v": 1}],
+            total_rows=1,
+            fields_dict=FIELDS,
+            existing_completed=[],
+            existing_results={},
+        )
+        checkpoint_files = list(tmp_path.glob("*_checkpoint.json"))
+        assert len(checkpoint_files) == 1
+        stat = checkpoint_files[0].stat()
+        assert stat.st_mode & 0o777 == 0o600
+
+    def test_custom_checkpoint_dir_constructor_arg_still_works(self, tmp_path):
+        """Regression: explicit checkpoint_dir= overrides the XDG default."""
+        custom = str(tmp_path / "custom_checkpoints")
+        config = EnrichmentConfig(checkpoint_dir=custom)
+        assert config.checkpoint_dir == custom


### PR DESCRIPTION
## Summary

- `_default_cache_dir()` uses `XDG_CACHE_HOME` (fallback: `~/.cache/accrue`); `_default_checkpoint_dir()` uses `XDG_STATE_HOME` (fallback: `~/.local/state/accrue`)
- Both fields now use `dataclasses.field(default_factory=...)` 
- `cache.db` and checkpoint files get `os.chmod(..., 0o600)` on POSIX after creation/atomic-replace

**Migration note:** existing users relying on the old `.accrue/` default should pass `cache_dir=".accrue"` explicitly or migrate `cache.db` to `~/.cache/accrue/` (or accept cache regeneration).

## Test plan

- [ ] `XDG_CACHE_HOME` respected for `cache_dir` default
- [ ] Falls back to `~/.cache/accrue` when `XDG_CACHE_HOME` unset
- [ ] `cache.db` created with `0o600` permissions (POSIX-only)
- [ ] Custom `cache_dir=` constructor arg still works (regression)
- [ ] Same 4 tests mirrored for `checkpoint_dir` / `XDG_STATE_HOME`
- [ ] `ruff check` and `ruff format --check` both clean
- [ ] All 72 cache + checkpoint tests pass

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)