### PR TITLE
test: add conftest.py with env scrub + network kill; convert tests/integration/ to proper pytest (#77)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,3 +28,47 @@ import pytest
 @pytest.fixture(autouse=True)
 def _isolate_cache_dir(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
+
+
+@pytest.fixture(autouse=True)
+def _scrub_provider_env_vars(monkeypatch):
+    """Remove real provider keys and substitute a dummy so non-empty checks pass.
+
+    Unit tests must never read credentials from the developer's shell.
+    This fixture scrubs all known provider env vars and injects a clearly
+    fake OpenAI key so code paths that assert ``key != ""`` still reach
+    the mock layer rather than blowing up at key-validation time.
+    """
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "test-mock-key-not-real")
+
+
+@pytest.fixture(autouse=True)
+def _block_network(monkeypatch):
+    """Raise on any real outbound HTTP in unit tests.
+
+    Patches both the async and sync ``httpx`` send methods so accidental
+    real API calls fail loudly with a clear message rather than hanging or
+    leaking billing charges.  Integration tests that need real network access
+    must be decorated with ``@pytest.mark.integration`` and kept under
+    ``tests/integration/`` (excluded from the default pytest run via
+    ``norecursedirs``).
+    """
+    import httpx
+
+    _msg = (
+        "Unit test attempted a real network call — "
+        "mock the provider client or use pytest.mark.integration"
+    )
+
+    def _raise_async(self, *args, **kwargs):
+        raise RuntimeError(_msg)
+
+    def _raise_sync(self, *args, **kwargs):
+        raise RuntimeError(_msg)
+
+    monkeypatch.setattr(httpx.AsyncClient, "send", _raise_async)
+    monkeypatch.setattr(httpx.Client, "send", _raise_sync)

--- a/tests/integration/test_anthropic_pipeline_batch.py
+++ b/tests/integration/test_anthropic_pipeline_batch.py
@@ -3,70 +3,74 @@
 Tests Pipeline.run() with an AnthropicClient and batch=True.
 """
 
-import sys
+import os
 
-sys.path.insert(0, ".")
+import pytest
 
-from dotenv import load_dotenv
 
-load_dotenv()
+@pytest.mark.integration
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="needs real OPENAI_API_KEY")
+def test_anthropic_pipeline_batch():
+    from dotenv import load_dotenv
 
-from accrue import EnrichmentConfig, LLMStep, Pipeline
-from accrue.steps.providers.anthropic import AnthropicClient
+    load_dotenv()
 
-client = AnthropicClient()
+    from accrue import EnrichmentConfig, LLMStep, Pipeline
+    from accrue.steps.providers.anthropic import AnthropicClient
 
-pipeline = Pipeline(
-    [
-        LLMStep(
-            "classify",
-            fields={
-                "category": {
-                    "prompt": "Classify this company's primary sector",
-                    "enum": ["Fintech", "SaaS", "E-commerce", "Healthcare", "Other"],
+    client = AnthropicClient()
+
+    pipeline = Pipeline(
+        [
+            LLMStep(
+                "classify",
+                fields={
+                    "category": {
+                        "prompt": "Classify this company's primary sector",
+                        "enum": ["Fintech", "SaaS", "E-commerce", "Healthcare", "Other"],
+                    },
                 },
-            },
-            model="claude-haiku-4-5-20251001",
-            client=client,
-            batch=True,
-        )
+                model="claude-haiku-4-5-20251001",
+                client=client,
+                batch=True,
+            )
+        ]
+    )
+
+    data = [
+        {"company": "Stripe", "description": "Online payment processing"},
+        {"company": "Notion", "description": "All-in-one workspace app"},
     ]
-)
 
-data = [
-    {"company": "Stripe", "description": "Online payment processing"},
-    {"company": "Notion", "description": "All-in-one workspace app"},
-]
+    config = EnrichmentConfig(
+        enable_progress_bar=False,
+        batch_poll_interval=10.0,
+        batch_timeout=600.0,
+    )
 
-config = EnrichmentConfig(
-    enable_progress_bar=False,
-    batch_poll_interval=10.0,
-    batch_timeout=600.0,
-)
+    print("=== Anthropic Pipeline Batch Test ===")
+    print(f"Submitting {len(data)} rows via Anthropic Batch API...")
+    print("(Polling every 10s, timeout 10min)\n")
 
-print("=== Anthropic Pipeline Batch Test ===")
-print(f"Submitting {len(data)} rows via Anthropic Batch API...")
-print("(Polling every 10s, timeout 10min)\n")
+    result = pipeline.run(data, config=config)
 
-result = pipeline.run(data, config=config)
+    print(f"Success rate: {result.success_rate:.0%}")
+    print(f"Errors: {len(result.errors)}")
+    print(f"Total tokens: {result.cost.total_tokens}")
 
-print(f"Success rate: {result.success_rate:.0%}")
-print(f"Errors: {len(result.errors)}")
-print(f"Total tokens: {result.cost.total_tokens}")
+    step_usage = result.cost.steps.get("classify")
+    if step_usage:
+        print(f"Execution mode: {step_usage.execution_mode}")
+        print(f"Batch ID: {step_usage.batch_id}")
 
-step_usage = result.cost.steps.get("classify")
-if step_usage:
-    print(f"Execution mode: {step_usage.execution_mode}")
-    print(f"Batch ID: {step_usage.batch_id}")
+    for row in result.data:
+        print(f"  {row['company']}: {row.get('category')}")
 
-for row in result.data:
-    print(f"  {row['company']}: {row.get('category')}")
+    assert result.success_rate == 1.0
+    assert step_usage.execution_mode == "batch"
+    assert step_usage.batch_id is not None
 
-assert result.success_rate == 1.0
-assert step_usage.execution_mode == "batch"
-assert step_usage.batch_id is not None
+    for row in result.data:
+        assert row.get("category") in ["Fintech", "SaaS", "E-commerce", "Healthcare", "Other"]
 
-for row in result.data:
-    assert row.get("category") in ["Fintech", "SaaS", "E-commerce", "Healthcare", "Other"]
-
-print("\n✓ Anthropic pipeline batch test PASSED")
+    print("\n✓ Anthropic pipeline batch test PASSED")

--- a/tests/integration/test_batch_anthropic_e2e.py
+++ b/tests/integration/test_batch_anthropic_e2e.py
@@ -3,103 +3,105 @@
 Tests the Anthropic Message Batches API end-to-end.
 """
 
-import sys
+import os
 
-sys.path.insert(0, ".")
-
-from dotenv import load_dotenv
-
-load_dotenv()
-
-import asyncio
-
-from accrue.steps.providers.anthropic import AnthropicClient
-from accrue.steps.providers.base import BatchCapableLLMClient, BatchRequest
+import pytest
 
 
-async def main():
-    client = AnthropicClient()
+@pytest.mark.integration
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="needs real OPENAI_API_KEY")
+def test_batch_anthropic_e2e():
+    from dotenv import load_dotenv
 
-    # 1. Protocol check
-    assert isinstance(client, BatchCapableLLMClient), (
-        "AnthropicClient should satisfy BatchCapableLLMClient"
-    )
-    print("✓ AnthropicClient satisfies BatchCapableLLMClient protocol")
+    load_dotenv()
 
-    # 2. Realtime call first (sanity check key works)
-    print("\nTest 1: Realtime call...")
-    response = await client.complete(
-        messages=[
-            {"role": "system", "content": 'Return JSON: {"answer": "value"}'},
-            {"role": "user", "content": "What is 2+2? Return as JSON."},
-        ],
-        model="claude-haiku-4-5-20251001",
-        temperature=0.0,
-        max_tokens=100,
-        response_format={"type": "json_object"},
-    )
-    print(f"  Realtime response: {response.content[:100]}")
-    print(f"  Tokens: {response.usage.total_tokens if response.usage else 'N/A'}")
-    print("  ✓ Realtime works")
+    import asyncio
 
-    # 3. Submit a batch
-    print("\nTest 2: Submit batch...")
-    requests = [
-        BatchRequest(
-            custom_id="row-0",
+    from accrue.steps.providers.anthropic import AnthropicClient
+    from accrue.steps.providers.base import BatchCapableLLMClient, BatchRequest
+
+    async def main():
+        client = AnthropicClient()
+
+        # 1. Protocol check
+        assert isinstance(client, BatchCapableLLMClient), (
+            "AnthropicClient should satisfy BatchCapableLLMClient"
+        )
+        print("✓ AnthropicClient satisfies BatchCapableLLMClient protocol")
+
+        # 2. Realtime call first (sanity check key works)
+        print("\nTest 1: Realtime call...")
+        response = await client.complete(
             messages=[
-                {"role": "system", "content": "Return valid JSON with the key 'greeting'."},
-                {"role": "user", "content": "Say hello to Alice. Return as JSON."},
+                {"role": "system", "content": 'Return JSON: {"answer": "value"}'},
+                {"role": "user", "content": "What is 2+2? Return as JSON."},
             ],
             model="claude-haiku-4-5-20251001",
             temperature=0.0,
             max_tokens=100,
-        ),
-        BatchRequest(
-            custom_id="row-1",
-            messages=[
-                {"role": "system", "content": "Return valid JSON with the key 'greeting'."},
-                {"role": "user", "content": "Say hello to Bob. Return as JSON."},
-            ],
-            model="claude-haiku-4-5-20251001",
-            temperature=0.0,
-            max_tokens=100,
-        ),
-    ]
+            response_format={"type": "json_object"},
+        )
+        print(f"  Realtime response: {response.content[:100]}")
+        print(f"  Tokens: {response.usage.total_tokens if response.usage else 'N/A'}")
+        print("  ✓ Realtime works")
 
-    batch_id = await client.submit_batch(requests)
-    print(f"  Batch submitted: {batch_id}")
+        # 3. Submit a batch
+        print("\nTest 2: Submit batch...")
+        requests = [
+            BatchRequest(
+                custom_id="row-0",
+                messages=[
+                    {"role": "system", "content": "Return valid JSON with the key 'greeting'."},
+                    {"role": "user", "content": "Say hello to Alice. Return as JSON."},
+                ],
+                model="claude-haiku-4-5-20251001",
+                temperature=0.0,
+                max_tokens=100,
+            ),
+            BatchRequest(
+                custom_id="row-1",
+                messages=[
+                    {"role": "system", "content": "Return valid JSON with the key 'greeting'."},
+                    {"role": "user", "content": "Say hello to Bob. Return as JSON."},
+                ],
+                model="claude-haiku-4-5-20251001",
+                temperature=0.0,
+                max_tokens=100,
+            ),
+        ]
 
-    # 4. Check status
-    inner = client._get_client()
-    batch = await inner.messages.batches.retrieve(batch_id)
-    print(f"  Status: {batch.processing_status}")
-    print("  ✓ Batch created on Anthropic")
+        batch_id = await client.submit_batch(requests)
+        print(f"  Batch submitted: {batch_id}")
 
-    # 5. Poll until complete (or timeout)
-    print("\nTest 3: Polling batch (15s interval, 10min timeout)...")
-    try:
-        result = await client.poll_batch(batch_id, poll_interval=15.0, timeout=600.0)
-        print("  ✓ Batch completed!")
-        print(f"  Responses: {len(result.responses)}")
-        print(f"  Failed: {len(result.failed_ids)}")
-        print(f"  Batch ID: {result.batch_id}")
-        for cid, resp in result.responses.items():
-            print(f"  {cid}: {resp.content[:80]}")
-            if resp.usage:
-                print(f"    tokens: {resp.usage.total_tokens}")
+        # 4. Check status
+        inner = client._get_client()
+        batch = await inner.messages.batches.retrieve(batch_id)
+        print(f"  Status: {batch.processing_status}")
+        print("  ✓ Batch created on Anthropic")
 
-        assert len(result.responses) == 2, f"Expected 2 responses, got {len(result.responses)}"
-        assert result.failed_ids == [], f"Unexpected failures: {result.failed_ids}"
-        print("\n✓ Anthropic Batch API E2E PASSED")
+        # 5. Poll until complete (or timeout)
+        print("\nTest 3: Polling batch (15s interval, 10min timeout)...")
+        try:
+            result = await client.poll_batch(batch_id, poll_interval=15.0, timeout=600.0)
+            print("  ✓ Batch completed!")
+            print(f"  Responses: {len(result.responses)}")
+            print(f"  Failed: {len(result.failed_ids)}")
+            print(f"  Batch ID: {result.batch_id}")
+            for cid, resp in result.responses.items():
+                print(f"  {cid}: {resp.content[:80]}")
+                if resp.usage:
+                    print(f"    tokens: {resp.usage.total_tokens}")
 
-    except Exception as e:
-        print(f"  Batch did not complete in time: {e}")
-        print(f"  Batch ID for manual check: {batch_id}")
-        # Cancel to clean up
-        await client.cancel_batch(batch_id)
-        print(f"  Cancelled batch {batch_id}")
-        print("\n⚠ Anthropic batch timed out (queue latency) — submit+poll logic verified")
+            assert len(result.responses) == 2, f"Expected 2 responses, got {len(result.responses)}"
+            assert result.failed_ids == [], f"Unexpected failures: {result.failed_ids}"
+            print("\n✓ Anthropic Batch API E2E PASSED")
 
+        except Exception as e:
+            print(f"  Batch did not complete in time: {e}")
+            print(f"  Batch ID for manual check: {batch_id}")
+            # Cancel to clean up
+            await client.cancel_batch(batch_id)
+            print(f"  Cancelled batch {batch_id}")
+            print("\n⚠ Anthropic batch timed out (queue latency) — submit+poll logic verified")
 
-asyncio.run(main())
+    asyncio.run(main())

--- a/tests/integration/test_batch_e2e.py
+++ b/tests/integration/test_batch_e2e.py
@@ -4,63 +4,67 @@ Uses a single tiny request to minimize wait time. Polls aggressively.
 Typically completes in 2-15 minutes.
 """
 
-import sys
+import os
 
-sys.path.insert(0, ".")
+import pytest
 
-from dotenv import load_dotenv
 
-load_dotenv()
+@pytest.mark.integration
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="needs real OPENAI_API_KEY")
+def test_batch_e2e():
+    from dotenv import load_dotenv
 
-from accrue import EnrichmentConfig, LLMStep, Pipeline
+    load_dotenv()
 
-pipeline = Pipeline(
-    [
-        LLMStep(
-            "test",
-            fields={
-                "greeting": "Say hello to this person by name",
-            },
-            model="gpt-4.1-nano",
-            batch=True,
-        )
-    ]
-)
+    from accrue import EnrichmentConfig, LLMStep, Pipeline
 
-data = [{"person": "Alice"}]
+    pipeline = Pipeline(
+        [
+            LLMStep(
+                "test",
+                fields={
+                    "greeting": "Say hello to this person by name",
+                },
+                model="gpt-4.1-nano",
+                batch=True,
+            )
+        ]
+    )
 
-config = EnrichmentConfig(
-    enable_progress_bar=False,
-    batch_poll_interval=15.0,  # Check every 15 seconds
-    batch_timeout=1800.0,  # 30 minute timeout
-)
+    data = [{"person": "Alice"}]
 
-print("=== End-to-End Batch Test ===")
-print("Submitting 1 row via Batch API...")
-print("(Polling every 15s, timeout 30min)\n")
+    config = EnrichmentConfig(
+        enable_progress_bar=False,
+        batch_poll_interval=15.0,  # Check every 15 seconds
+        batch_timeout=1800.0,  # 30 minute timeout
+    )
 
-result = pipeline.run(data, config=config)
+    print("=== End-to-End Batch Test ===")
+    print("Submitting 1 row via Batch API...")
+    print("(Polling every 15s, timeout 30min)\n")
 
-print(f"Success rate: {result.success_rate:.0%}")
-print(f"Errors: {len(result.errors)}")
-print(f"Total tokens: {result.cost.total_tokens}")
+    result = pipeline.run(data, config=config)
 
-step_usage = result.cost.steps.get("test")
-if step_usage:
-    print(f"Execution mode: {step_usage.execution_mode}")
-    print(f"Batch ID: {step_usage.batch_id}")
+    print(f"Success rate: {result.success_rate:.0%}")
+    print(f"Errors: {len(result.errors)}")
+    print(f"Total tokens: {result.cost.total_tokens}")
 
-for row in result.data:
-    print(f"  Result: {row.get('greeting')}")
+    step_usage = result.cost.steps.get("test")
+    if step_usage:
+        print(f"Execution mode: {step_usage.execution_mode}")
+        print(f"Batch ID: {step_usage.batch_id}")
 
-assert result.success_rate == 1.0, f"Expected 100% success, got {result.success_rate}"
-assert result.cost.total_tokens > 0, "Expected token usage"
-assert step_usage.execution_mode == "batch"
-assert step_usage.batch_id is not None
+    for row in result.data:
+        print(f"  Result: {row.get('greeting')}")
 
-greeting = result.data[0].get("greeting", "")
-assert "Alice" in greeting or "alice" in greeting.lower(), (
-    f"Expected greeting to mention Alice: {greeting}"
-)
+    assert result.success_rate == 1.0, f"Expected 100% success, got {result.success_rate}"
+    assert result.cost.total_tokens > 0, "Expected token usage"
+    assert step_usage.execution_mode == "batch"
+    assert step_usage.batch_id is not None
 
-print("\n✓ End-to-end batch test PASSED")
+    greeting = result.data[0].get("greeting", "")
+    assert "Alice" in greeting or "alice" in greeting.lower(), (
+        f"Expected greeting to mention Alice: {greeting}"
+    )
+
+    print("\n✓ End-to-end batch test PASSED")

--- a/tests/integration/test_batch_mechanics.py
+++ b/tests/integration/test_batch_mechanics.py
@@ -7,129 +7,133 @@ Tests:
   4. batch=True + non-batch client falls back to realtime
 """
 
-import sys
+import os
 
-sys.path.insert(0, ".")
-
-from dotenv import load_dotenv
-
-load_dotenv()
-
-import asyncio
-
-from accrue import EnrichmentConfig, LLMStep
-from accrue.schemas.base import UsageInfo
-from accrue.steps.base import StepContext
-from accrue.steps.providers.base import LLMResponse
-
-print("=== Batch Mechanics Test ===\n")
-
-# --- Test 1: build_messages produces valid structure ---
-print("Test 1: build_messages()")
-step = LLMStep(
-    "test",
-    fields={"category": {"prompt": "Classify the company", "enum": ["Tech", "Finance", "Other"]}},
-    model="gpt-4.1-nano",
-    batch=True,
-)
-
-ctx = StepContext(
-    row={"company": "Stripe", "description": "Payments"},
-    fields={"category": {"prompt": "Classify"}},
-    prior_results={},
-    config=EnrichmentConfig(),
-)
-
-messages, kwargs = step.build_messages(ctx)
-assert len(messages) == 2, f"Expected 2 messages, got {len(messages)}"
-assert messages[0]["role"] == "system"
-assert messages[1]["role"] == "user"
-assert kwargs["model"] == "gpt-4.1-nano"
-assert kwargs["temperature"] == 0.2
-assert kwargs["max_tokens"] == 4000
-assert kwargs["response_format"] is not None
-print(f"  ✓ Messages: {len(messages)} messages, model={kwargs['model']}")
-
-# --- Test 2: parse_response handles real format ---
-print("Test 2: parse_response()")
-response = LLMResponse(
-    content='{"category": "Tech"}',
-    usage=UsageInfo(prompt_tokens=10, completion_tokens=3, total_tokens=13, model="gpt-4.1-nano"),
-)
-result = step.parse_response(response)
-assert result.values == {"category": "Tech"}, f"Unexpected values: {result.values}"
-assert result.usage.total_tokens == 13
-print(f"  ✓ Parsed: {result.values}")
-
-# Test parse with refusal → default
-step_with_default = LLMStep(
-    "test2",
-    fields={"risk": {"prompt": "Assess risk", "default": "Unknown"}},
-    batch=True,
-)
-response2 = LLMResponse(content='{"risk": "N/A"}', usage=None)
-result2 = step_with_default.parse_response(response2)
-assert result2.values["risk"] == "Unknown", f"Default not applied: {result2.values}"
-print(f"  ✓ Default enforcement: 'N/A' → '{result2.values['risk']}'")
-
-# --- Test 3: is_batch_eligible ---
-print("Test 3: is_batch_eligible")
-# OpenAIClient satisfies BatchCapableLLMClient
-batch_step = LLMStep("s", fields=["f"], batch=True)
-assert batch_step.is_batch_eligible is True, "OpenAIClient should be batch eligible"
-print("  ✓ OpenAIClient + batch=True → eligible")
-
-non_batch_step = LLMStep("s", fields=["f"], batch=False)
-assert non_batch_step.is_batch_eligible is False
-print("  ✓ batch=False → not eligible")
-
-# --- Test 4: batch=True with non-batch client falls back ---
-print("Test 4: Non-batch client fallback")
+import pytest
 
 
-class SimpleClient:
-    async def complete(
-        self, messages, model, temperature, max_tokens, response_format=None, tools=None
-    ):
-        return LLMResponse(content='{"f": "value"}', usage=UsageInfo(total_tokens=1))
+@pytest.mark.integration
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="needs real OPENAI_API_KEY")
+def test_batch_mechanics():
+    from dotenv import load_dotenv
 
+    load_dotenv()
 
-custom_step = LLMStep("s", fields=["f"], client=SimpleClient(), batch=True)
-assert custom_step.is_batch_eligible is False, "SimpleClient should not be batch eligible"
-print("  ✓ Custom non-batch client + batch=True → not eligible (will use realtime)")
+    import asyncio
 
-# --- Test 5: Real API call through build_messages → complete → parse_response ---
-print("Test 5: build_messages → real API call → parse_response")
+    from accrue import EnrichmentConfig, LLMStep
+    from accrue.schemas.base import UsageInfo
+    from accrue.steps.base import StepContext
+    from accrue.steps.providers.base import LLMResponse
 
+    print("=== Batch Mechanics Test ===\n")
 
-async def test_real_call():
+    # --- Test 1: build_messages produces valid structure ---
+    print("Test 1: build_messages()")
     step = LLMStep(
-        "real_test",
-        fields={"answer": {"prompt": "What is 2+2?", "type": "String"}},
+        "test",
+        fields={
+            "category": {"prompt": "Classify the company", "enum": ["Tech", "Finance", "Other"]}
+        },
         model="gpt-4.1-nano",
+        batch=True,
     )
+
     ctx = StepContext(
-        row={"question": "math"},
-        fields={},
+        row={"company": "Stripe", "description": "Payments"},
+        fields={"category": {"prompt": "Classify"}},
         prior_results={},
         config=EnrichmentConfig(),
     )
+
     messages, kwargs = step.build_messages(ctx)
-    client = step._resolve_client()
-    response = await client.complete(
-        messages=messages,
-        model=kwargs["model"],
-        temperature=kwargs["temperature"],
-        max_tokens=kwargs["max_tokens"],
-        response_format=kwargs["response_format"],
+    assert len(messages) == 2, f"Expected 2 messages, got {len(messages)}"
+    assert messages[0]["role"] == "system"
+    assert messages[1]["role"] == "user"
+    assert kwargs["model"] == "gpt-4.1-nano"
+    assert kwargs["temperature"] == 0.2
+    assert kwargs["max_tokens"] == 4000
+    assert kwargs["response_format"] is not None
+    print(f"  ✓ Messages: {len(messages)} messages, model={kwargs['model']}")
+
+    # --- Test 2: parse_response handles real format ---
+    print("Test 2: parse_response()")
+    response = LLMResponse(
+        content='{"category": "Tech"}',
+        usage=UsageInfo(
+            prompt_tokens=10, completion_tokens=3, total_tokens=13, model="gpt-4.1-nano"
+        ),
     )
     result = step.parse_response(response)
-    assert "answer" in result.values, f"Missing answer: {result.values}"
-    print(
-        f"  ✓ Real API: answer={result.values['answer']}, tokens={result.usage.total_tokens if result.usage else 'N/A'}"
+    assert result.values == {"category": "Tech"}, f"Unexpected values: {result.values}"
+    assert result.usage.total_tokens == 13
+    print(f"  ✓ Parsed: {result.values}")
+
+    # Test parse with refusal → default
+    step_with_default = LLMStep(
+        "test2",
+        fields={"risk": {"prompt": "Assess risk", "default": "Unknown"}},
+        batch=True,
     )
+    response2 = LLMResponse(content='{"risk": "N/A"}', usage=None)
+    result2 = step_with_default.parse_response(response2)
+    assert result2.values["risk"] == "Unknown", f"Default not applied: {result2.values}"
+    print(f"  ✓ Default enforcement: 'N/A' → '{result2.values['risk']}'")
 
+    # --- Test 3: is_batch_eligible ---
+    print("Test 3: is_batch_eligible")
+    # OpenAIClient satisfies BatchCapableLLMClient
+    batch_step = LLMStep("s", fields=["f"], batch=True)
+    assert batch_step.is_batch_eligible is True, "OpenAIClient should be batch eligible"
+    print("  ✓ OpenAIClient + batch=True → eligible")
 
-asyncio.run(test_real_call())
+    non_batch_step = LLMStep("s", fields=["f"], batch=False)
+    assert non_batch_step.is_batch_eligible is False
+    print("  ✓ batch=False → not eligible")
 
-print("\n✓ Batch mechanics test PASSED")
+    # --- Test 4: batch=True with non-batch client falls back ---
+    print("Test 4: Non-batch client fallback")
+
+    class SimpleClient:
+        async def complete(
+            self, messages, model, temperature, max_tokens, response_format=None, tools=None
+        ):
+            return LLMResponse(content='{"f": "value"}', usage=UsageInfo(total_tokens=1))
+
+    custom_step = LLMStep("s", fields=["f"], client=SimpleClient(), batch=True)
+    assert custom_step.is_batch_eligible is False, "SimpleClient should not be batch eligible"
+    print("  ✓ Custom non-batch client + batch=True → not eligible (will use realtime)")
+
+    # --- Test 5: Real API call through build_messages → complete → parse_response ---
+    print("Test 5: build_messages → real API call → parse_response")
+
+    async def test_real_call():
+        step = LLMStep(
+            "real_test",
+            fields={"answer": {"prompt": "What is 2+2?", "type": "String"}},
+            model="gpt-4.1-nano",
+        )
+        ctx = StepContext(
+            row={"question": "math"},
+            fields={},
+            prior_results={},
+            config=EnrichmentConfig(),
+        )
+        messages, kwargs = step.build_messages(ctx)
+        client = step._resolve_client()
+        response = await client.complete(
+            messages=messages,
+            model=kwargs["model"],
+            temperature=kwargs["temperature"],
+            max_tokens=kwargs["max_tokens"],
+            response_format=kwargs["response_format"],
+        )
+        result = step.parse_response(response)
+        assert "answer" in result.values, f"Missing answer: {result.values}"
+        print(
+            f"  ✓ Real API: answer={result.values['answer']}, tokens={result.usage.total_tokens if result.usage else 'N/A'}"
+        )
+
+    asyncio.run(test_real_call())
+
+    print("\n✓ Batch mechanics test PASSED")

--- a/tests/integration/test_batch_mixed_pipeline.py
+++ b/tests/integration/test_batch_mixed_pipeline.py
@@ -7,117 +7,119 @@ Verifies that:
   4. Caching works: second run serves from cache, no batch submitted
 """
 
-import sys
+import os
 
-sys.path.insert(0, ".")
-
-from dotenv import load_dotenv
-
-load_dotenv()
-
-from accrue import (
-    EnrichmentConfig,
-    EnrichmentHooks,
-    FunctionStep,
-    LLMStep,
-    Pipeline,
-    StepEndEvent,
-    StepStartEvent,
-)
-
-# Track step events to verify execution modes
-events = []
+import pytest
 
 
-def on_step_start(event: StepStartEvent):
-    print(f"  → {event.step_name} starting (rows={event.num_rows})")
-    events.append(("start", event.step_name))
+@pytest.mark.integration
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="needs real OPENAI_API_KEY")
+def test_batch_mixed_pipeline():
+    from dotenv import load_dotenv
 
+    load_dotenv()
 
-def on_step_end(event: StepEndEvent):
-    mode = event.execution_mode
-    batch_info = f", batch_id={event.batch_id}" if event.batch_id else ""
-    print(f"  ✓ {event.step_name} done ({mode}, {event.elapsed_seconds:.1f}s{batch_info})")
-    events.append(("end", event.step_name, mode))
-
-
-def enrich_context(ctx):
-    """Simple FunctionStep that adds context."""
-    company = ctx.row.get("company", "Unknown")
-    return {"__context": f"{company} is a technology company."}
-
-
-pipeline = Pipeline(
-    [
-        FunctionStep("context", fn=enrich_context, fields=["__context"]),
-        LLMStep(
-            "analyze",
-            fields={
-                "summary": "Write a brief one-sentence summary based on the context",
-            },
-            model="gpt-4.1-nano",
-            batch=True,
-            depends_on=["context"],
-        ),
-    ]
-)
-
-data = [
-    {"company": "Stripe"},
-    {"company": "Figma"},
-]
-
-config = EnrichmentConfig(
-    enable_progress_bar=False,
-    enable_caching=True,
-    batch_poll_interval=10.0,
-    batch_timeout=600.0,
-)
-
-hooks = EnrichmentHooks(on_step_start=on_step_start, on_step_end=on_step_end)
-
-# === Run 1: First execution ===
-print("=== Mixed Pipeline Test ===")
-print(f"\nRun 1: Processing {len(data)} rows (FunctionStep → Batch LLMStep)...")
-events.clear()
-
-result = pipeline.run(data, config=config, hooks=hooks)
-
-print(f"\nSuccess rate: {result.success_rate:.0%}")
-print(f"Total tokens: {result.cost.total_tokens}")
-for row in result.data:
-    print(f"  {row['company']}: {row.get('summary', 'N/A')}")
-
-# Assertions for run 1
-assert result.success_rate == 1.0
-assert len(result.errors) == 0
-
-analyze_usage = result.cost.steps.get("analyze")
-assert analyze_usage is not None, "Expected analyze step usage"
-assert analyze_usage.execution_mode == "batch", (
-    f"Expected batch, got {analyze_usage.execution_mode}"
-)
-assert analyze_usage.cache_misses > 0, "Expected cache misses on first run"
-
-for row in result.data:
-    assert row.get("summary"), f"Missing summary for {row['company']}"
-
-# === Run 2: Cached execution ===
-print("\nRun 2: Same data — should be 100% cache hits...")
-events.clear()
-
-result2 = pipeline.run(data, config=config, hooks=hooks)
-
-print(f"Success rate: {result2.success_rate:.0%}")
-analyze_usage2 = result2.cost.steps.get("analyze")
-if analyze_usage2:
-    print(f"Cache hits: {analyze_usage2.cache_hits}, misses: {analyze_usage2.cache_misses}")
-    assert analyze_usage2.cache_hits == 2, f"Expected 2 cache hits, got {analyze_usage2.cache_hits}"
-    assert analyze_usage2.cache_misses == 0, (
-        f"Expected 0 cache misses, got {analyze_usage2.cache_misses}"
+    from accrue import (
+        EnrichmentConfig,
+        EnrichmentHooks,
+        FunctionStep,
+        LLMStep,
+        Pipeline,
+        StepEndEvent,
+        StepStartEvent,
     )
 
-# Clean up cache
-pipeline.clear_cache()
+    # Track step events to verify execution modes
+    events = []
 
-print("\n✓ Mixed pipeline test PASSED")
+    def on_step_start(event: StepStartEvent):
+        print(f"  → {event.step_name} starting (rows={event.num_rows})")
+        events.append(("start", event.step_name))
+
+    def on_step_end(event: StepEndEvent):
+        mode = event.execution_mode
+        batch_info = f", batch_id={event.batch_id}" if event.batch_id else ""
+        print(f"  ✓ {event.step_name} done ({mode}, {event.elapsed_seconds:.1f}s{batch_info})")
+        events.append(("end", event.step_name, mode))
+
+    def enrich_context(ctx):
+        """Simple FunctionStep that adds context."""
+        company = ctx.row.get("company", "Unknown")
+        return {"__context": f"{company} is a technology company."}
+
+    pipeline = Pipeline(
+        [
+            FunctionStep("context", fn=enrich_context, fields=["__context"]),
+            LLMStep(
+                "analyze",
+                fields={
+                    "summary": "Write a brief one-sentence summary based on the context",
+                },
+                model="gpt-4.1-nano",
+                batch=True,
+                depends_on=["context"],
+            ),
+        ]
+    )
+
+    data = [
+        {"company": "Stripe"},
+        {"company": "Figma"},
+    ]
+
+    config = EnrichmentConfig(
+        enable_progress_bar=False,
+        enable_caching=True,
+        batch_poll_interval=10.0,
+        batch_timeout=600.0,
+    )
+
+    hooks = EnrichmentHooks(on_step_start=on_step_start, on_step_end=on_step_end)
+
+    # === Run 1: First execution ===
+    print("=== Mixed Pipeline Test ===")
+    print(f"\nRun 1: Processing {len(data)} rows (FunctionStep → Batch LLMStep)...")
+    events.clear()
+
+    result = pipeline.run(data, config=config, hooks=hooks)
+
+    print(f"\nSuccess rate: {result.success_rate:.0%}")
+    print(f"Total tokens: {result.cost.total_tokens}")
+    for row in result.data:
+        print(f"  {row['company']}: {row.get('summary', 'N/A')}")
+
+    # Assertions for run 1
+    assert result.success_rate == 1.0
+    assert len(result.errors) == 0
+
+    analyze_usage = result.cost.steps.get("analyze")
+    assert analyze_usage is not None, "Expected analyze step usage"
+    assert analyze_usage.execution_mode == "batch", (
+        f"Expected batch, got {analyze_usage.execution_mode}"
+    )
+    assert analyze_usage.cache_misses > 0, "Expected cache misses on first run"
+
+    for row in result.data:
+        assert row.get("summary"), f"Missing summary for {row['company']}"
+
+    # === Run 2: Cached execution ===
+    print("\nRun 2: Same data — should be 100% cache hits...")
+    events.clear()
+
+    result2 = pipeline.run(data, config=config, hooks=hooks)
+
+    print(f"Success rate: {result2.success_rate:.0%}")
+    analyze_usage2 = result2.cost.steps.get("analyze")
+    if analyze_usage2:
+        print(f"Cache hits: {analyze_usage2.cache_hits}, misses: {analyze_usage2.cache_misses}")
+        assert analyze_usage2.cache_hits == 2, (
+            f"Expected 2 cache hits, got {analyze_usage2.cache_hits}"
+        )
+        assert analyze_usage2.cache_misses == 0, (
+            f"Expected 0 cache misses, got {analyze_usage2.cache_misses}"
+        )
+
+    # Clean up cache
+    pipeline.clear_cache()
+
+    print("\n✓ Mixed pipeline test PASSED")

--- a/tests/integration/test_batch_openai.py
+++ b/tests/integration/test_batch_openai.py
@@ -7,84 +7,88 @@ NOTE: Batch API can take 1-60 minutes. This test uses a small dataset
 and aggressive polling to keep it short.
 """
 
-import sys
+import os
 
-sys.path.insert(0, ".")
+import pytest
 
-from dotenv import load_dotenv
 
-load_dotenv()
+@pytest.mark.integration
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="needs real OPENAI_API_KEY")
+def test_batch_openai():
+    from dotenv import load_dotenv
 
-from accrue import EnrichmentConfig, LLMStep, Pipeline
+    load_dotenv()
 
-pipeline = Pipeline(
-    [
-        LLMStep(
-            "classify",
-            fields={
-                "category": {
-                    "prompt": "Classify this company's primary industry sector",
-                    "enum": ["Fintech", "SaaS", "E-commerce", "Healthcare", "Other"],
+    from accrue import EnrichmentConfig, LLMStep, Pipeline
+
+    pipeline = Pipeline(
+        [
+            LLMStep(
+                "classify",
+                fields={
+                    "category": {
+                        "prompt": "Classify this company's primary industry sector",
+                        "enum": ["Fintech", "SaaS", "E-commerce", "Healthcare", "Other"],
+                    },
+                    "one_liner": {
+                        "prompt": "Write a one-sentence description of what this company does",
+                        "type": "String",
+                    },
                 },
-                "one_liner": {
-                    "prompt": "Write a one-sentence description of what this company does",
-                    "type": "String",
-                },
-            },
-            model="gpt-4.1-nano",
-            batch=True,  # <-- USE BATCH API
-        )
+                model="gpt-4.1-nano",
+                batch=True,  # <-- USE BATCH API
+            )
+        ]
+    )
+
+    data = [
+        {"company": "Stripe", "description": "Online payment processing platform"},
+        {"company": "Notion", "description": "All-in-one workspace for notes and projects"},
+        {"company": "Vercel", "description": "Cloud platform for frontend deployment"},
     ]
-)
 
-data = [
-    {"company": "Stripe", "description": "Online payment processing platform"},
-    {"company": "Notion", "description": "All-in-one workspace for notes and projects"},
-    {"company": "Vercel", "description": "Cloud platform for frontend deployment"},
-]
-
-config = EnrichmentConfig(
-    enable_progress_bar=False,
-    batch_poll_interval=10.0,  # Poll every 10 seconds (batch can be fast)
-    batch_timeout=600.0,  # 10 min timeout for this test
-)
-
-print("=== OpenAI Batch API Test ===")
-print(f"Submitting {len(data)} rows via Batch API...")
-print("(This may take 1-5 minutes for the batch to process)\n")
-
-result = pipeline.run(data, config=config)
-
-print(f"Success rate: {result.success_rate:.0%}")
-print(f"Errors: {len(result.errors)}")
-print(f"Total tokens: {result.cost.total_tokens}")
-
-step_usage = result.cost.steps.get("classify")
-if step_usage:
-    print(f"Execution mode: {step_usage.execution_mode}")
-    print(f"Batch ID: {step_usage.batch_id}")
-    print(f"Cache hits: {step_usage.cache_hits}, misses: {step_usage.cache_misses}")
-
-print()
-for row in result.data:
-    print(f"  {row['company']}: category={row.get('category')}")
-    print(f"    {row.get('one_liner', 'N/A')}")
-
-# Assertions
-assert result.success_rate == 1.0, f"Expected 100% success, got {result.success_rate}"
-assert len(result.errors) == 0, f"Expected 0 errors, got {len(result.errors)}"
-assert result.cost.total_tokens > 0, "Expected token usage"
-
-if step_usage:
-    assert step_usage.execution_mode == "batch", (
-        f"Expected batch execution mode, got {step_usage.execution_mode}"
+    config = EnrichmentConfig(
+        enable_progress_bar=False,
+        batch_poll_interval=10.0,  # Poll every 10 seconds (batch can be fast)
+        batch_timeout=600.0,  # 10 min timeout for this test
     )
-    assert step_usage.batch_id, "Expected batch_id to be set"
 
-for row in result.data:
-    assert row.get("category") in ["Fintech", "SaaS", "E-commerce", "Healthcare", "Other"], (
-        f"Unexpected category: {row.get('category')}"
-    )
-    assert row.get("one_liner"), "Missing one_liner"
+    print("=== OpenAI Batch API Test ===")
+    print(f"Submitting {len(data)} rows via Batch API...")
+    print("(This may take 1-5 minutes for the batch to process)\n")
 
-print("\n✓ OpenAI Batch API test PASSED")
+    result = pipeline.run(data, config=config)
+
+    print(f"Success rate: {result.success_rate:.0%}")
+    print(f"Errors: {len(result.errors)}")
+    print(f"Total tokens: {result.cost.total_tokens}")
+
+    step_usage = result.cost.steps.get("classify")
+    if step_usage:
+        print(f"Execution mode: {step_usage.execution_mode}")
+        print(f"Batch ID: {step_usage.batch_id}")
+        print(f"Cache hits: {step_usage.cache_hits}, misses: {step_usage.cache_misses}")
+
+    print()
+    for row in result.data:
+        print(f"  {row['company']}: category={row.get('category')}")
+        print(f"    {row.get('one_liner', 'N/A')}")
+
+    # Assertions
+    assert result.success_rate == 1.0, f"Expected 100% success, got {result.success_rate}"
+    assert len(result.errors) == 0, f"Expected 0 errors, got {len(result.errors)}"
+    assert result.cost.total_tokens > 0, "Expected token usage"
+
+    if step_usage:
+        assert step_usage.execution_mode == "batch", (
+            f"Expected batch execution mode, got {step_usage.execution_mode}"
+        )
+        assert step_usage.batch_id, "Expected batch_id to be set"
+
+    for row in result.data:
+        assert row.get("category") in ["Fintech", "SaaS", "E-commerce", "Healthcare", "Other"], (
+            f"Unexpected category: {row.get('category')}"
+        )
+        assert row.get("one_liner"), "Missing one_liner"
+
+    print("\n✓ OpenAI Batch API test PASSED")

--- a/tests/integration/test_batch_poll_existing.py
+++ b/tests/integration/test_batch_poll_existing.py
@@ -1,49 +1,51 @@
 """Poll an existing OpenAI batch to verify result download and parsing works."""
 
-import sys
+import os
 
-sys.path.insert(0, ".")
-
-from dotenv import load_dotenv
-
-load_dotenv()
-
-import asyncio
-
-from accrue.steps.providers.openai import OpenAIClient
+import pytest
 
 BATCH_ID = "batch_69c3b827e46c8190a6848d0e0289da7f"
 
 
-async def main():
-    client = OpenAIClient()
+@pytest.mark.integration
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="needs real OPENAI_API_KEY")
+def test_batch_poll_existing():
+    from dotenv import load_dotenv
 
-    # First just check the status
-    inner = client._get_client()
-    batch = await inner.batches.retrieve(BATCH_ID)
-    print(f"Batch {BATCH_ID}")
-    print(f"  Status: {batch.status}")
-    print(f"  Request counts: {batch.request_counts}")
+    load_dotenv()
 
-    if batch.status == "completed":
-        print("\nBatch is complete! Downloading results...")
-        result = await client._download_batch_results(batch, BATCH_ID)
-        print(f"  Responses: {len(result.responses)}")
-        print(f"  Failed: {len(result.failed_ids)}")
-        for cid, resp in result.responses.items():
-            print(f"  {cid}: {resp.content[:100]}...")
-            print(f"    tokens: {resp.usage.total_tokens if resp.usage else 'N/A'}")
-        print("\n✓ Batch result download and parsing PASSED")
-    elif batch.status == "in_progress":
-        print("\nBatch still processing. Waiting with 30s poll interval...")
-        result = await client.poll_batch(BATCH_ID, poll_interval=30.0, timeout=1800.0)
-        print(f"  Responses: {len(result.responses)}")
-        print(f"  Failed: {len(result.failed_ids)}")
-        for cid, resp in result.responses.items():
-            print(f"  {cid}: {resp.content[:100]}...")
-        print("\n✓ Batch result download and parsing PASSED")
-    else:
-        print(f"\nBatch is in status '{batch.status}' — cannot download results")
+    import asyncio
 
+    from accrue.steps.providers.openai import OpenAIClient
 
-asyncio.run(main())
+    async def main():
+        client = OpenAIClient()
+
+        # First just check the status
+        inner = client._get_client()
+        batch = await inner.batches.retrieve(BATCH_ID)
+        print(f"Batch {BATCH_ID}")
+        print(f"  Status: {batch.status}")
+        print(f"  Request counts: {batch.request_counts}")
+
+        if batch.status == "completed":
+            print("\nBatch is complete! Downloading results...")
+            result = await client._download_batch_results(batch, BATCH_ID)
+            print(f"  Responses: {len(result.responses)}")
+            print(f"  Failed: {len(result.failed_ids)}")
+            for cid, resp in result.responses.items():
+                print(f"  {cid}: {resp.content[:100]}...")
+                print(f"    tokens: {resp.usage.total_tokens if resp.usage else 'N/A'}")
+            print("\n✓ Batch result download and parsing PASSED")
+        elif batch.status == "in_progress":
+            print("\nBatch still processing. Waiting with 30s poll interval...")
+            result = await client.poll_batch(BATCH_ID, poll_interval=30.0, timeout=1800.0)
+            print(f"  Responses: {len(result.responses)}")
+            print(f"  Failed: {len(result.failed_ids)}")
+            for cid, resp in result.responses.items():
+                print(f"  {cid}: {resp.content[:100]}...")
+            print("\n✓ Batch result download and parsing PASSED")
+        else:
+            print(f"\nBatch is in status '{batch.status}' — cannot download results")
+
+    asyncio.run(main())

--- a/tests/integration/test_batch_submit_verify.py
+++ b/tests/integration/test_batch_submit_verify.py
@@ -4,67 +4,69 @@ This test submits a tiny batch, verifies it was created on OpenAI's side,
 then cancels it (to avoid waiting). Tests the submit + status check path.
 """
 
-import sys
+import os
 
-sys.path.insert(0, ".")
-
-from dotenv import load_dotenv
-
-load_dotenv()
-
-import asyncio
-
-from accrue.steps.providers.base import BatchCapableLLMClient, BatchRequest
-from accrue.steps.providers.openai import OpenAIClient
+import pytest
 
 
-async def main():
-    client = OpenAIClient()
+@pytest.mark.integration
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="needs real OPENAI_API_KEY")
+def test_batch_submit_verify():
+    from dotenv import load_dotenv
 
-    # Verify protocol compliance
-    assert isinstance(client, BatchCapableLLMClient), (
-        "OpenAIClient should satisfy BatchCapableLLMClient"
-    )
-    print("✓ OpenAIClient satisfies BatchCapableLLMClient protocol")
+    load_dotenv()
 
-    # Submit a tiny batch
-    requests = [
-        BatchRequest(
-            custom_id="test-row-0",
-            messages=[
-                {"role": "system", "content": 'Return JSON: {"answer": "hello"}'},
-                {"role": "user", "content": "Say hello."},
-            ],
-            model="gpt-4.1-nano",
-            temperature=0.0,
-            max_tokens=50,
-            response_format={"type": "json_object"},
-        ),
-    ]
+    import asyncio
 
-    batch_id = await client.submit_batch(requests, metadata={"test": "integration"})
-    print(f"✓ Batch submitted: {batch_id}")
+    from accrue.steps.providers.base import BatchCapableLLMClient, BatchRequest
+    from accrue.steps.providers.openai import OpenAIClient
 
-    # Verify it exists on OpenAI
-    inner = client._get_client()
-    batch = await inner.batches.retrieve(batch_id)
-    assert batch.status in ("validating", "in_progress", "finalizing", "completed"), (
-        f"Unexpected status: {batch.status}"
-    )
-    print(f"✓ Batch status: {batch.status}")
-    print(f"  Request counts: {batch.request_counts}")
-    # During 'validating', total may be 0 — counts populate after validation
-    print(f"✓ Request counts reported: total={batch.request_counts.total}")
+    async def main():
+        client = OpenAIClient()
 
-    # Cancel it (we don't want to wait)
-    await client.cancel_batch(batch_id)
-    print(f"✓ Cancel requested for {batch_id}")
+        # Verify protocol compliance
+        assert isinstance(client, BatchCapableLLMClient), (
+            "OpenAIClient should satisfy BatchCapableLLMClient"
+        )
+        print("✓ OpenAIClient satisfies BatchCapableLLMClient protocol")
 
-    # Also cancel the earlier batch from the timeout test
-    await client.cancel_batch("batch_69c3b827e46c8190a6848d0e0289da7f")
-    print("✓ Cancelled earlier test batch too")
+        # Submit a tiny batch
+        requests = [
+            BatchRequest(
+                custom_id="test-row-0",
+                messages=[
+                    {"role": "system", "content": 'Return JSON: {"answer": "hello"}'},
+                    {"role": "user", "content": "Say hello."},
+                ],
+                model="gpt-4.1-nano",
+                temperature=0.0,
+                max_tokens=50,
+                response_format={"type": "json_object"},
+            ),
+        ]
 
-    print("\n✓ Batch submit+verify test PASSED")
+        batch_id = await client.submit_batch(requests, metadata={"test": "integration"})
+        print(f"✓ Batch submitted: {batch_id}")
 
+        # Verify it exists on OpenAI
+        inner = client._get_client()
+        batch = await inner.batches.retrieve(batch_id)
+        assert batch.status in ("validating", "in_progress", "finalizing", "completed"), (
+            f"Unexpected status: {batch.status}"
+        )
+        print(f"✓ Batch status: {batch.status}")
+        print(f"  Request counts: {batch.request_counts}")
+        # During 'validating', total may be 0 — counts populate after validation
+        print(f"✓ Request counts reported: total={batch.request_counts.total}")
 
-asyncio.run(main())
+        # Cancel it (we don't want to wait)
+        await client.cancel_batch(batch_id)
+        print(f"✓ Cancel requested for {batch_id}")
+
+        # Also cancel the earlier batch from the timeout test
+        await client.cancel_batch("batch_69c3b827e46c8190a6848d0e0289da7f")
+        print("✓ Cancelled earlier test batch too")
+
+        print("\n✓ Batch submit+verify test PASSED")
+
+    asyncio.run(main())

--- a/tests/integration/test_provider_kwargs.py
+++ b/tests/integration/test_provider_kwargs.py
@@ -1,102 +1,108 @@
 """Integration test: provider_kwargs passthrough + prompt caching."""
 
-import sys
+import os
 
-sys.path.insert(0, ".")
-
-from dotenv import load_dotenv
-
-load_dotenv()
-
-import asyncio
-
-from accrue import EnrichmentConfig, LLMStep, Pipeline
-from accrue.steps.providers.anthropic import AnthropicClient
+import pytest
 
 
-async def main():
-    client = AnthropicClient()
+@pytest.mark.integration
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="needs real OPENAI_API_KEY")
+def test_provider_kwargs():
+    from dotenv import load_dotenv
 
-    # Test 1: provider_kwargs with thinking
-    print("Test 1: provider_kwargs with extended thinking", flush=True)
-    resp = await client.complete(
-        messages=[
-            {"role": "system", "content": "Return JSON with key answer"},
-            {"role": "user", "content": 'What is 15 * 23? Return {"answer": N}'},
-        ],
-        model="claude-haiku-4-5-20251001",
-        temperature=1,  # thinking requires temperature=1
-        max_tokens=8000,
-        provider_kwargs={
-            "thinking": {"type": "enabled", "budget_tokens": 2000},
-        },
-    )
-    print(f"  Response: {resp.content[:100]}", flush=True)
-    print(f"  Tokens: {resp.usage.total_tokens if resp.usage else 'N/A'}", flush=True)
-    assert "345" in resp.content, f"Expected 345 in response: {resp.content}"
-    print("  ✓ thinking via provider_kwargs works", flush=True)
+    load_dotenv()
 
-    # Test 2: prompt caching (system message has cache_control)
-    print("\nTest 2: Prompt caching (Anthropic)", flush=True)
-    long_system = "You are a helpful assistant. Return valid JSON. " * 50
-    for i in range(2):
+    import asyncio
+
+    from accrue import EnrichmentConfig, LLMStep, Pipeline
+    from accrue.steps.providers.anthropic import AnthropicClient
+
+    async def main():
+        client = AnthropicClient()
+
+        # Test 1: provider_kwargs with thinking
+        print("Test 1: provider_kwargs with extended thinking", flush=True)
         resp = await client.complete(
             messages=[
-                {"role": "system", "content": long_system},
-                {"role": "user", "content": f'What is {i + 1}+1? Return {{"answer": N}}'},
+                {"role": "system", "content": "Return JSON with key answer"},
+                {"role": "user", "content": 'What is 15 * 23? Return {"answer": N}'},
             ],
             model="claude-haiku-4-5-20251001",
-            temperature=0,
-            max_tokens=100,
+            temperature=1,  # thinking requires temperature=1
+            max_tokens=8000,
+            provider_kwargs={
+                "thinking": {"type": "enabled", "budget_tokens": 2000},
+            },
         )
-        print(
-            f"  Call {i + 1}: tokens={resp.usage.total_tokens if resp.usage else 'N/A'}", flush=True
-        )
-    print("  ✓ Prompt caching enabled (cache_control on system message)", flush=True)
+        print(f"  Response: {resp.content[:100]}", flush=True)
+        print(f"  Tokens: {resp.usage.total_tokens if resp.usage else 'N/A'}", flush=True)
+        assert "345" in resp.content, f"Expected 345 in response: {resp.content}"
+        print("  ✓ thinking via provider_kwargs works", flush=True)
 
-    # Test 3: provider_kwargs through Pipeline.run()
-    print("\nTest 3: provider_kwargs through Pipeline.run()", flush=True)
-    pipeline = Pipeline(
-        [
-            LLMStep(
-                "classify",
-                fields={
-                    "category": {"prompt": "Classify sector", "enum": ["Tech", "Finance", "Other"]}
-                },
+        # Test 2: prompt caching (system message has cache_control)
+        print("\nTest 2: Prompt caching (Anthropic)", flush=True)
+        long_system = "You are a helpful assistant. Return valid JSON. " * 50
+        for i in range(2):
+            resp = await client.complete(
+                messages=[
+                    {"role": "system", "content": long_system},
+                    {"role": "user", "content": f'What is {i + 1}+1? Return {{"answer": N}}'},
+                ],
                 model="claude-haiku-4-5-20251001",
-                client=AnthropicClient(),
-                provider_kwargs={"metadata": {"user_id": "test-123"}},
+                temperature=0,
+                max_tokens=100,
             )
-        ]
-    )
-    result = await pipeline.run_async(
-        [{"company": "Stripe", "description": "Payments"}],
-        config=EnrichmentConfig(enable_progress_bar=False),
-    )
-    print(f"  Result: {result.data[0].get('category')}", flush=True)
-    print(f"  Tokens: {result.cost.total_tokens}", flush=True)
-    assert result.data[0].get("category") in ["Tech", "Finance", "Other"]
-    print("  ✓ provider_kwargs flows through Pipeline.run()", flush=True)
+            print(
+                f"  Call {i + 1}: tokens={resp.usage.total_tokens if resp.usage else 'N/A'}",
+                flush=True,
+            )
+        print("  ✓ Prompt caching enabled (cache_control on system message)", flush=True)
 
-    # Test 4: OpenAI provider_kwargs
-    print("\nTest 4: OpenAI provider_kwargs", flush=True)
-    from accrue.steps.providers.openai import OpenAIClient
+        # Test 3: provider_kwargs through Pipeline.run()
+        print("\nTest 3: provider_kwargs through Pipeline.run()", flush=True)
+        pipeline = Pipeline(
+            [
+                LLMStep(
+                    "classify",
+                    fields={
+                        "category": {
+                            "prompt": "Classify sector",
+                            "enum": ["Tech", "Finance", "Other"],
+                        }
+                    },
+                    model="claude-haiku-4-5-20251001",
+                    client=AnthropicClient(),
+                    provider_kwargs={"metadata": {"user_id": "test-123"}},
+                )
+            ]
+        )
+        result = await pipeline.run_async(
+            [{"company": "Stripe", "description": "Payments"}],
+            config=EnrichmentConfig(enable_progress_bar=False),
+        )
+        print(f"  Result: {result.data[0].get('category')}", flush=True)
+        print(f"  Tokens: {result.cost.total_tokens}", flush=True)
+        assert result.data[0].get("category") in ["Tech", "Finance", "Other"]
+        print("  ✓ provider_kwargs flows through Pipeline.run()", flush=True)
 
-    oai = OpenAIClient()
-    resp = await oai.complete(
-        messages=[
-            {"role": "system", "content": "Return JSON"},
-            {"role": "user", "content": 'What is 2+2? Return {"answer": N}'},
-        ],
-        model="gpt-4.1-nano",
-        temperature=0,
-        max_tokens=50,
-        provider_kwargs={"store": False},  # OpenAI-specific param
-    )
-    print(f"  Response: {resp.content}", flush=True)
-    print("  ✓ OpenAI provider_kwargs works", flush=True)
+        # Test 4: OpenAI provider_kwargs
+        print("\nTest 4: OpenAI provider_kwargs", flush=True)
+        from accrue.steps.providers.openai import OpenAIClient
 
-    print("\n✓ All provider_kwargs + prompt caching tests PASSED", flush=True)
+        oai = OpenAIClient()
+        resp = await oai.complete(
+            messages=[
+                {"role": "system", "content": "Return JSON"},
+                {"role": "user", "content": 'What is 2+2? Return {"answer": N}'},
+            ],
+            model="gpt-4.1-nano",
+            temperature=0,
+            max_tokens=50,
+            provider_kwargs={"store": False},  # OpenAI-specific param
+        )
+        print(f"  Response: {resp.content}", flush=True)
+        print("  ✓ OpenAI provider_kwargs works", flush=True)
 
+        print("\n✓ All provider_kwargs + prompt caching tests PASSED", flush=True)
 
-asyncio.run(main())
+    asyncio.run(main())

--- a/tests/integration/test_realtime_baseline.py
+++ b/tests/integration/test_realtime_baseline.py
@@ -3,63 +3,67 @@
 Verifies the existing realtime path still works end-to-end with a real API call.
 """
 
-import sys
+import os
 
-sys.path.insert(0, ".")
+import pytest
 
-from dotenv import load_dotenv
 
-load_dotenv()
+@pytest.mark.integration
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="needs real OPENAI_API_KEY")
+def test_realtime_baseline():
+    from dotenv import load_dotenv
 
-from accrue import EnrichmentConfig, LLMStep, Pipeline
+    load_dotenv()
 
-pipeline = Pipeline(
-    [
-        LLMStep(
-            "classify",
-            fields={
-                "category": {
-                    "prompt": "Classify this company's primary industry sector",
-                    "enum": ["Fintech", "SaaS", "E-commerce", "Healthcare", "Other"],
+    from accrue import EnrichmentConfig, LLMStep, Pipeline
+
+    pipeline = Pipeline(
+        [
+            LLMStep(
+                "classify",
+                fields={
+                    "category": {
+                        "prompt": "Classify this company's primary industry sector",
+                        "enum": ["Fintech", "SaaS", "E-commerce", "Healthcare", "Other"],
+                    },
+                    "employee_estimate": {
+                        "prompt": "Estimate number of employees (rough order of magnitude)",
+                        "type": "String",
+                    },
                 },
-                "employee_estimate": {
-                    "prompt": "Estimate number of employees (rough order of magnitude)",
-                    "type": "String",
-                },
-            },
-            model="gpt-4.1-nano",
-        )
+                model="gpt-4.1-nano",
+            )
+        ]
+    )
+
+    data = [
+        {"company": "Stripe", "description": "Online payment processing platform"},
+        {"company": "Shopify", "description": "E-commerce platform for online stores"},
     ]
-)
 
-data = [
-    {"company": "Stripe", "description": "Online payment processing platform"},
-    {"company": "Shopify", "description": "E-commerce platform for online stores"},
-]
+    print("=== Realtime Baseline Test ===")
+    print(f"Processing {len(data)} rows via realtime API...")
 
-print("=== Realtime Baseline Test ===")
-print(f"Processing {len(data)} rows via realtime API...")
+    result = pipeline.run(data, config=EnrichmentConfig(enable_progress_bar=False))
 
-result = pipeline.run(data, config=EnrichmentConfig(enable_progress_bar=False))
+    print(f"Success rate: {result.success_rate:.0%}")
+    print(f"Errors: {len(result.errors)}")
+    print(f"Total tokens: {result.cost.total_tokens}")
 
-print(f"Success rate: {result.success_rate:.0%}")
-print(f"Errors: {len(result.errors)}")
-print(f"Total tokens: {result.cost.total_tokens}")
+    for row in result.data:
+        print(
+            f"  {row['company']}: category={row.get('category')}, employees={row.get('employee_estimate')}"
+        )
 
-for row in result.data:
-    print(
-        f"  {row['company']}: category={row.get('category')}, employees={row.get('employee_estimate')}"
-    )
+    # Assertions
+    assert result.success_rate == 1.0, f"Expected 100% success, got {result.success_rate}"
+    assert len(result.errors) == 0, f"Expected 0 errors, got {len(result.errors)}"
+    assert result.cost.total_tokens > 0, "Expected token usage"
 
-# Assertions
-assert result.success_rate == 1.0, f"Expected 100% success, got {result.success_rate}"
-assert len(result.errors) == 0, f"Expected 0 errors, got {len(result.errors)}"
-assert result.cost.total_tokens > 0, "Expected token usage"
+    for row in result.data:
+        assert row.get("category") in ["Fintech", "SaaS", "E-commerce", "Healthcare", "Other"], (
+            f"Unexpected category: {row.get('category')}"
+        )
+        assert row.get("employee_estimate") is not None, "Missing employee_estimate"
 
-for row in result.data:
-    assert row.get("category") in ["Fintech", "SaaS", "E-commerce", "Healthcare", "Other"], (
-        f"Unexpected category: {row.get('category')}"
-    )
-    assert row.get("employee_estimate") is not None, "Missing employee_estimate"
-
-print("\n✓ Realtime baseline PASSED")
+    print("\n✓ Realtime baseline PASSED")

--- a/tests/integration/test_thinking_models.py
+++ b/tests/integration/test_thinking_models.py
@@ -4,164 +4,166 @@ Tests adaptive thinking (Claude 4.6) and extended thinking (older models)
 through the provider_kwargs escape hatch, both realtime and via Pipeline.
 """
 
-import sys
+import os
 
-sys.path.insert(0, ".")
-
-from dotenv import load_dotenv
-
-load_dotenv()
-
-import asyncio
-
-from accrue import EnrichmentConfig, LLMStep, Pipeline
-from accrue.steps.providers.anthropic import AnthropicClient
+import pytest
 
 
-async def main():
-    client = AnthropicClient()
+@pytest.mark.integration
+@pytest.mark.skipif(not os.getenv("OPENAI_API_KEY"), reason="needs real OPENAI_API_KEY")
+def test_thinking_models():
+    from dotenv import load_dotenv
 
-    # ── Test 1: Adaptive thinking (Claude Sonnet 4.6) ─────────────────
-    print("Test 1: Adaptive thinking (claude-sonnet-4-6)", flush=True)
-    resp = await client.complete(
-        messages=[
-            {"role": "system", "content": "Return valid JSON with key 'answer'."},
-            {
-                "role": "user",
-                "content": "How many r's are in the word 'strawberry'? Return {\"answer\": N}",
+    load_dotenv()
+
+    import asyncio
+
+    from accrue import EnrichmentConfig, LLMStep, Pipeline
+    from accrue.steps.providers.anthropic import AnthropicClient
+
+    async def main():
+        client = AnthropicClient()
+
+        # ── Test 1: Adaptive thinking (Claude Sonnet 4.6) ─────────────────
+        print("Test 1: Adaptive thinking (claude-sonnet-4-6)", flush=True)
+        resp = await client.complete(
+            messages=[
+                {"role": "system", "content": "Return valid JSON with key 'answer'."},
+                {
+                    "role": "user",
+                    "content": "How many r's are in the word 'strawberry'? Return {\"answer\": N}",
+                },
+            ],
+            model="claude-sonnet-4-6",
+            temperature=1,  # adaptive thinking works with temperature=1
+            max_tokens=16000,
+            provider_kwargs={
+                "thinking": {"type": "adaptive"},
             },
-        ],
-        model="claude-sonnet-4-6",
-        temperature=1,  # adaptive thinking works with temperature=1
-        max_tokens=16000,
-        provider_kwargs={
-            "thinking": {"type": "adaptive"},
-        },
-    )
-    print(f"  Response: {resp.content[:120]}", flush=True)
-    print(
-        f"  Tokens: prompt={resp.usage.prompt_tokens}, completion={resp.usage.completion_tokens}, total={resp.usage.total_tokens}",
-        flush=True,
-    )
-    assert "3" in resp.content, f"Expected 3 r's in strawberry: {resp.content}"
-    print("  ✓ Adaptive thinking works — correct answer", flush=True)
+        )
+        print(f"  Response: {resp.content[:120]}", flush=True)
+        print(
+            f"  Tokens: prompt={resp.usage.prompt_tokens}, completion={resp.usage.completion_tokens}, total={resp.usage.total_tokens}",
+            flush=True,
+        )
+        assert "3" in resp.content, f"Expected 3 r's in strawberry: {resp.content}"
+        print("  ✓ Adaptive thinking works — correct answer", flush=True)
 
-    # ── Test 2: Extended thinking with budget (Haiku 4.5) ─────────────
-    print("\nTest 2: Extended thinking with budget (claude-haiku-4-5)", flush=True)
-    resp2 = await client.complete(
-        messages=[
-            {"role": "system", "content": "Return valid JSON with key 'answer'."},
-            {"role": "user", "content": 'What is 17 * 29? Return {"answer": N}'},
-        ],
-        model="claude-haiku-4-5-20251001",
-        temperature=1,
-        max_tokens=8000,
-        provider_kwargs={
-            "thinking": {"type": "enabled", "budget_tokens": 2000},
-        },
-    )
-    print(f"  Response: {resp2.content[:120]}", flush=True)
-    print(f"  Tokens: total={resp2.usage.total_tokens}", flush=True)
-    assert "493" in resp2.content, f"Expected 493: {resp2.content}"
-    print("  ✓ Extended thinking with budget works", flush=True)
+        # ── Test 2: Extended thinking with budget (Haiku 4.5) ─────────────
+        print("\nTest 2: Extended thinking with budget (claude-haiku-4-5)", flush=True)
+        resp2 = await client.complete(
+            messages=[
+                {"role": "system", "content": "Return valid JSON with key 'answer'."},
+                {"role": "user", "content": 'What is 17 * 29? Return {"answer": N}'},
+            ],
+            model="claude-haiku-4-5-20251001",
+            temperature=1,
+            max_tokens=8000,
+            provider_kwargs={
+                "thinking": {"type": "enabled", "budget_tokens": 2000},
+            },
+        )
+        print(f"  Response: {resp2.content[:120]}", flush=True)
+        print(f"  Tokens: total={resp2.usage.total_tokens}", flush=True)
+        assert "493" in resp2.content, f"Expected 493: {resp2.content}"
+        print("  ✓ Extended thinking with budget works", flush=True)
 
-    # ── Test 3: Adaptive thinking through Pipeline.run() ──────────────
-    print("\nTest 3: Pipeline with adaptive thinking (claude-sonnet-4-6)", flush=True)
-    pipeline = Pipeline(
-        [
-            LLMStep(
-                "solve",
-                fields={
-                    "answer": {
-                        "prompt": "Solve this math problem step by step and give the final answer",
-                        "type": "String",
+        # ── Test 3: Adaptive thinking through Pipeline.run() ──────────────
+        print("\nTest 3: Pipeline with adaptive thinking (claude-sonnet-4-6)", flush=True)
+        pipeline = Pipeline(
+            [
+                LLMStep(
+                    "solve",
+                    fields={
+                        "answer": {
+                            "prompt": "Solve this math problem step by step and give the final answer",
+                            "type": "String",
+                        },
                     },
-                },
-                model="claude-sonnet-4-6",
-                client=AnthropicClient(),
-                temperature=1,
-                max_tokens=16000,
-                provider_kwargs={
-                    "thinking": {"type": "adaptive"},
-                },
-            )
-        ]
-    )
-
-    data = [
-        {"problem": "If a train travels at 60 mph for 2.5 hours, how far does it go?"},
-        {"problem": "What is the sum of the first 10 prime numbers?"},
-    ]
-
-    result = await pipeline.run_async(
-        data,
-        config=EnrichmentConfig(enable_progress_bar=False),
-    )
-
-    print(f"  Success rate: {result.success_rate:.0%}", flush=True)
-    print(f"  Total tokens: {result.cost.total_tokens}", flush=True)
-    for row in result.data:
-        print(f"  Problem: {row['problem'][:50]}...", flush=True)
-        print(f"    Answer: {row.get('answer', 'N/A')[:80]}", flush=True)
-
-    assert result.success_rate == 1.0, f"Expected 100% success: {result.errors}"
-    assert result.data[0].get("answer"), "Missing answer for problem 1"
-    assert result.data[1].get("answer"), "Missing answer for problem 2"
-    print("  ✓ Pipeline with adaptive thinking works", flush=True)
-
-    # ── Test 4: Thinking + batch mode ─────────────────────────────────
-    print("\nTest 4: Batch + thinking (claude-haiku-4-5)", flush=True)
-    batch_pipeline = Pipeline(
-        [
-            LLMStep(
-                "solve",
-                fields={
-                    "result": {
-                        "prompt": "Calculate the answer to this math problem",
-                        "type": "String",
+                    model="claude-sonnet-4-6",
+                    client=AnthropicClient(),
+                    temperature=1,
+                    max_tokens=16000,
+                    provider_kwargs={
+                        "thinking": {"type": "adaptive"},
                     },
-                },
-                model="claude-haiku-4-5-20251001",
-                client=AnthropicClient(),
-                temperature=1,
-                max_tokens=8000,
-                batch=True,
-                provider_kwargs={
-                    "thinking": {"type": "enabled", "budget_tokens": 2000},
-                },
-            )
+                )
+            ]
+        )
+
+        data = [
+            {"problem": "If a train travels at 60 mph for 2.5 hours, how far does it go?"},
+            {"problem": "What is the sum of the first 10 prime numbers?"},
         ]
-    )
 
-    batch_data = [
-        {"problem": "What is 12 * 13?"},
-        {"problem": "What is 99 + 101?"},
-    ]
+        result = await pipeline.run_async(
+            data,
+            config=EnrichmentConfig(enable_progress_bar=False),
+        )
 
-    batch_result = await batch_pipeline.run_async(
-        batch_data,
-        config=EnrichmentConfig(
-            enable_progress_bar=False,
-            batch_poll_interval=10.0,
-            batch_timeout=600.0,
-        ),
-    )
+        print(f"  Success rate: {result.success_rate:.0%}", flush=True)
+        print(f"  Total tokens: {result.cost.total_tokens}", flush=True)
+        for row in result.data:
+            print(f"  Problem: {row['problem'][:50]}...", flush=True)
+            print(f"    Answer: {row.get('answer', 'N/A')[:80]}", flush=True)
 
-    print(f"  Success rate: {batch_result.success_rate:.0%}", flush=True)
-    print(f"  Total tokens: {batch_result.cost.total_tokens}", flush=True)
-    step_usage = batch_result.cost.steps.get("solve")
-    if step_usage:
-        print(f"  Execution mode: {step_usage.execution_mode}", flush=True)
-        print(f"  Batch ID: {step_usage.batch_id}", flush=True)
-    for row in batch_result.data:
-        print(f"  {row['problem']}: {row.get('result', 'N/A')}", flush=True)
+        assert result.success_rate == 1.0, f"Expected 100% success: {result.errors}"
+        assert result.data[0].get("answer"), "Missing answer for problem 1"
+        assert result.data[1].get("answer"), "Missing answer for problem 2"
+        print("  ✓ Pipeline with adaptive thinking works", flush=True)
 
-    assert batch_result.success_rate == 1.0, f"Batch failed: {batch_result.errors}"
-    if step_usage:
-        assert step_usage.execution_mode == "batch"
-    print("  ✓ Batch + thinking works", flush=True)
+        # ── Test 4: Thinking + batch mode ─────────────────────────────────
+        print("\nTest 4: Batch + thinking (claude-haiku-4-5)", flush=True)
+        batch_pipeline = Pipeline(
+            [
+                LLMStep(
+                    "solve",
+                    fields={
+                        "result": {
+                            "prompt": "Calculate the answer to this math problem",
+                            "type": "String",
+                        },
+                    },
+                    model="claude-haiku-4-5-20251001",
+                    client=AnthropicClient(),
+                    temperature=1,
+                    max_tokens=8000,
+                    batch=True,
+                    provider_kwargs={
+                        "thinking": {"type": "enabled", "budget_tokens": 2000},
+                    },
+                )
+            ]
+        )
 
-    print("\n✓ All thinking model tests PASSED", flush=True)
+        batch_data = [
+            {"problem": "What is 12 * 13?"},
+            {"problem": "What is 99 + 101?"},
+        ]
 
+        batch_result = await batch_pipeline.run_async(
+            batch_data,
+            config=EnrichmentConfig(
+                enable_progress_bar=False,
+                batch_poll_interval=10.0,
+                batch_timeout=600.0,
+            ),
+        )
 
-asyncio.run(main())
+        print(f"  Success rate: {batch_result.success_rate:.0%}", flush=True)
+        print(f"  Total tokens: {batch_result.cost.total_tokens}", flush=True)
+        step_usage = batch_result.cost.steps.get("solve")
+        if step_usage:
+            print(f"  Execution mode: {step_usage.execution_mode}", flush=True)
+            print(f"  Batch ID: {step_usage.batch_id}", flush=True)
+        for row in batch_result.data:
+            print(f"  {row['problem']}: {row.get('result', 'N/A')}", flush=True)
+
+        assert batch_result.success_rate == 1.0, f"Batch failed: {batch_result.errors}"
+        if step_usage:
+            assert step_usage.execution_mode == "batch"
+        print("  ✓ Batch + thinking works", flush=True)
+
+        print("\n✓ All thinking model tests PASSED", flush=True)
+
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

- Adds `tests/conftest.py` autouse fixtures that scrub real API keys and block network calls in unit tests
- Converts all 11 `tests/integration/*.py` scripts to proper `def test_*` functions with `@pytest.mark.integration` and `@pytest.mark.skipif(not OPENAI_API_KEY)` decorators
- Modules are now safe to import without side effects; `load_dotenv()` and pipeline construction moved inside test bodies

## Changes

- `tests/conftest.py`: added `_scrub_provider_env_vars` (removes OPENAI/ANTHROPIC/GOOGLE/GEMINI keys, injects dummy) and `_block_network` (patches `httpx.AsyncClient.send` + `httpx.Client.send` to raise RuntimeError)
- `tests/integration/*.py` (11 files): wrapped all script bodies in `def test_*`, added both markers, moved imports inside function scope
- `pyproject.toml`: unchanged — `norecursedirs = ["tests/integration"]` and `integration` marker already present

## Testing

1. `pytest -x -q` → 592 unit tests pass, offline, no network calls
2. `python -c "import tests.integration.test_batch_openai"` → import ok, no side effects
3. `OPENAI_API_KEY= pytest tests/integration/` → 11 skipped, 0 failed
4. `ruff check accrue/ tests/` → all checks passed
5. `ruff format --check accrue/ tests/` → 67 files already formatted

## Checklist

- [x] Lint passes
- [x] Tests pass (592 unit tests)
- [x] No evals needed — infra-only change, no behavioral effect
- [x] Labels copied from source issue + ai-attribution applied
- [x] Self-reviewed
- [x] No new dependencies added (stdlib monkeypatch only)
- [x] `pyproject.toml` marker registration verified (already present)

Closes #77