### PR TITLE
polish: round-3 follow-ups (google regex, 408 timeout, legacy checkpoint, batch cancel warning)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `LLMStep.parse_response` now strips markdown code fences before `json.loads`. Fixes parse failures with Claude Haiku + grounding tools, where the structured-output constraint is disabled and the model wraps JSON in ` ``` ` fences. (#7)
 - `accrue/__init__.py` `__version__` was out of sync with `pyproject.toml`.
+- Google provider: Option-B rate-limit fallback now uses a word-boundary regex (`\brate[\s_-]?limit\b`) instead of bare `"rate" in exc_str`, preventing false positives on words like "iterate" or "accelerator". (#80)
+- Google provider: `DeadlineExceeded` errors now set `status_code=408` (both typed Option-A and substring Option-B paths) for consistency with the Anthropic adapter. (#80)
+- Checkpoint: pre-1.2.1 files using the legacy `__type__` sentinel are now detected, logged as a `WARNING`, and discarded so pipelines resume cleanly instead of silently misreading typed values. (#80)
+- Pipeline: submit-batch cleanup now logs a `WARNING` for any `cancel_batch` failures so users know if orphaned batches may still be billable after a submit error. (#80)
+
+### Internal
+- `AnthropicClient._warned_grounding_schema` is per-client-instance scope (not per-process). `LLMStep` constructs a fresh client per `Pipeline.run_async()` call, so the grounding-schema incompatibility warning fires once per run. (#80)
 
 ## [1.2.0] - 2026-04-25
 

--- a/accrue/core/checkpoint.py
+++ b/accrue/core/checkpoint.py
@@ -58,10 +58,24 @@ def _typed_decoder(d: dict) -> Any:
     treated as encoded library values — any extra keys means it's user data
     and must be returned unchanged.  Dicts without ``__accrue_type__`` are
     also returned as-is (covers plain user data and the outer checkpoint
-    structure).  Old checkpoint files written with ``__type__`` (pre-#63)
-    pass through as plain dicts; they won't deserialise their typed values
-    but they won't crash either.
+    structure).
+
+    Legacy checkpoint files written with ``__type__`` (pre-1.2.1) would
+    silently produce plain dicts with incorrect types on resume.  We detect
+    this format and discard the checkpoint so the user gets a clean start
+    with a clear warning rather than a silent misparse.
     """
+    if d.keys() == {"__type__", "value"} and d["__type__"] in (
+        "datetime",
+        "Decimal",
+        "set",
+        "numpy",
+    ):
+        logger.warning(
+            "Legacy checkpoint format detected (pre-1.2.1 __type__ sentinel); "
+            "discarding checkpoint and starting fresh."
+        )
+        raise json.JSONDecodeError("Legacy checkpoint format — discarded", doc="", pos=0)
     if d.keys() != {"__accrue_type__", "value"}:
         return d
     t = d["__accrue_type__"]
@@ -266,6 +280,11 @@ class CheckpointManager:
                 f"({', '.join(data.completed_steps)})"
             )
             return data
+        except json.JSONDecodeError:
+            # JSONDecodeError is raised by _typed_decoder for legacy checkpoints
+            # (pre-1.2.1 __type__ sentinel) after logging a WARNING there.
+            # Return None to give the pipeline a clean start.
+            return None
         except Exception as e:
             logger.error(f"Failed to load checkpoint: {e}")
             return None

--- a/accrue/pipeline/pipeline.py
+++ b/accrue/pipeline/pipeline.py
@@ -1198,10 +1198,22 @@ class Pipeline:
         except Exception:
             # Best-effort cancel of already-submitted batches before propagating
             if batch_ids:
-                await asyncio.gather(
+                cancel_results = await asyncio.gather(
                     *(client.cancel_batch(bid) for bid in batch_ids),
                     return_exceptions=True,
                 )
+                failures = [
+                    (bid, r)
+                    for bid, r in zip(batch_ids, cancel_results)
+                    if isinstance(r, BaseException)
+                ]
+                if failures:
+                    logger.warning(
+                        "Failed to cancel %d orphaned batch(es) after submit failure; "
+                        "these may still be billable: %s",
+                        len(failures),
+                        [(bid, type(err).__name__) for bid, err in failures],
+                    )
             raise
 
         # ── Phase 4: Poll (with KeyboardInterrupt handling) ────────────

--- a/accrue/steps/providers/anthropic.py
+++ b/accrue/steps/providers/anthropic.py
@@ -38,6 +38,9 @@ class AnthropicClient:
         self._api_key = api_key
         self._http_client = http_client
         self._client: Any = None
+        # Scope: per-client-instance (not per-process).  LLMStep constructs a
+        # fresh AnthropicClient on each Pipeline.run_async() call, so users see
+        # this warning once per pipeline run rather than once per process lifetime.
         self._warned_grounding_schema: bool = False
 
     def _get_client(self) -> Any:

--- a/accrue/steps/providers/google.py
+++ b/accrue/steps/providers/google.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from typing import Any
 
 from ...schemas.base import UsageInfo
@@ -11,6 +12,10 @@ from ...schemas.grounding import Citation
 from .base import LLMAPIError, LLMResponse
 
 logger = logging.getLogger(__name__)
+
+# Word-boundary regex for rate-limit detection in Option-B fallback.
+# Avoids false positives on words like "iterate", "accelerator", "rated".
+_RATE_LIMIT_RE = re.compile(r"\b(rate[\s_-]?limit|resource\s+exhausted)\b", re.IGNORECASE)
 
 # Lazily resolved; populated once on first exception classification.
 # google-api-core ships with google-genai so it will normally be present,
@@ -174,6 +179,7 @@ def _classify_google_exc(exc: Exception, model: str) -> LLMAPIError:
             return LLMAPIError(
                 f"Google deadline exceeded for model '{model}': {exc}",
                 retryable=True,
+                status_code=408,
             )
         if isinstance(
             exc,
@@ -189,28 +195,30 @@ def _classify_google_exc(exc: Exception, model: str) -> LLMAPIError:
             )
 
     # Option B — substring heuristics (fallback for unknown types)
-    exc_str = str(exc).lower()
-    if "429" in exc_str or "resource exhausted" in exc_str or "rate" in exc_str:
+    exc_str = str(exc)
+    if "429" in exc_str or _RATE_LIMIT_RE.search(exc_str):
         return LLMAPIError(
             f"Google rate limit for model '{model}': {exc}",
             is_rate_limit=True,
             status_code=429,
         )
+    exc_str_lower = exc_str.lower()
     for code, marker in [
         (500, "internal server error"),
         (502, "bad gateway"),
         (503, "service unavailable"),
         (504, "gateway timeout"),
     ]:
-        if marker in exc_str:
+        if marker in exc_str_lower:
             return LLMAPIError(
                 f"Google server error for model '{model}': {exc}",
                 status_code=code,
             )
-    if "deadline exceeded" in exc_str or "timeout" in exc_str:
+    if "deadline exceeded" in exc_str_lower or "timeout" in exc_str_lower:
         return LLMAPIError(
             f"Google timeout for model '{model}': {exc}",
             retryable=True,
+            status_code=408,
         )
     return LLMAPIError(f"Google API error for model '{model}': {exc}")
 

--- a/tests/test_batch_pipeline.py
+++ b/tests/test_batch_pipeline.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -524,3 +525,36 @@ class TestBatchCancellationCleanup:
         client.cancel_batch.assert_not_called()
         assert result.data[0]["market_size"] == "$5B"
         assert result.data[1]["market_size"] == "$3B"
+
+    @pytest.mark.asyncio
+    async def test_cancel_failure_after_submit_failure_logs_warning(self, caplog):
+        """If cancel_batch raises during cleanup, a WARNING is logged before re-raise."""
+        submit_call_count = 0
+
+        async def submit_side_effect(requests, metadata=None):
+            nonlocal submit_call_count
+            submit_call_count += 1
+            if submit_call_count == 1:
+                return "batch_chunk_1"
+            raise RuntimeError("Submit failed on chunk 2")
+
+        async def cancel_side_effect(bid):
+            raise RuntimeError(f"cancel failed for {bid}")
+
+        client = AsyncMock(spec=["complete", "submit_batch", "poll_batch", "cancel_batch"])
+        client.complete = AsyncMock(return_value=_mock_llm_response('{"market_size": "$1B"}'))
+        client.submit_batch = submit_side_effect
+        client.poll_batch = AsyncMock()
+        client.cancel_batch = cancel_side_effect
+
+        step = _make_batch_step(client=client)
+        pipeline = Pipeline([step])
+        config = EnrichmentConfig(batch_max_requests=1)
+
+        with caplog.at_level(logging.WARNING, logger="accrue.pipeline.pipeline"):
+            with pytest.raises(RuntimeError, match="Submit failed"):
+                await pipeline.run_async([{"company": "Acme"}, {"company": "Beta"}], config=config)
+
+        assert "orphaned" in caplog.text.lower() or "billable" in caplog.text.lower(), (
+            "A warning about orphaned/billable batches must be logged when cancel fails"
+        )

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -531,3 +531,32 @@ class TestPartialCheckpoint:
         # Only step1 is completed; step2 must NOT appear.
         assert cp.completed_steps == ["step1"]
         assert "step2" not in cp.completed_steps
+
+
+# -- Legacy checkpoint format (fix #80) -------------------------------------
+
+
+class TestLegacyCheckpointDetection:
+    def test_legacy_type_sentinel_returns_none_and_warns(self, tmp_path, caplog):
+        """Pre-1.2.1 checkpoint using __type__ must be discarded with a WARNING."""
+        mgr = _make_mgr(tmp_path)
+
+        # Write a checkpoint file containing the old __type__ sentinel
+        legacy_payload = {
+            "timestamp": 1000.0,
+            "category": "cat",
+            "total_rows": 1,
+            "fields_dict": {"col": {}},
+            "completed_steps": ["step1"],
+            "step_results": {
+                "step1": [{"val": {"__type__": "datetime", "value": "2024-01-01T00:00:00"}}]
+            },
+        }
+        path = mgr._get_path("data", "cat")
+        path.write_text(json.dumps(legacy_payload), encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING, logger="accrue.core.checkpoint"):
+            result = mgr.load("data", "cat")
+
+        assert result is None, "Legacy checkpoint must be discarded (return None)"
+        assert "Legacy checkpoint format" in caplog.text, "A WARNING must be logged"

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1444,3 +1444,69 @@ class TestGoogleClient:
         assert exc_info.value.retryable is True
         assert exc_info.value.is_rate_limit is True
         assert exc_info.value.status_code == 429
+
+    # -- Word-boundary regex (fix #80) ----------------------------------------
+
+    def _reload_google_no_api_core(self):
+        """Remove google.api_core so tests exercise the Option-B substring path."""
+        import importlib
+        import sys
+
+        self._install_mock_google()
+        sys.modules.pop("google.api_core", None)
+        sys.modules.pop("google.api_core.exceptions", None)
+        import accrue.steps.providers.google as _google_mod
+
+        importlib.reload(_google_mod)
+        from accrue.steps.providers.google import _classify_google_exc
+
+        return _classify_google_exc
+
+    def test_iterate_does_not_classify_as_rate_limit(self):
+        """'iterate' must NOT trigger the rate-limit branch (word-boundary guard)."""
+        classify = self._reload_google_no_api_core()
+        exc = Exception("failed to iterate over results")
+        result = classify(exc, "gemini-2.5-flash")
+        assert result.is_rate_limit is False
+
+    def test_rate_limit_string_does_classify_as_rate_limit(self):
+        """'rate limit' MUST trigger the rate-limit branch."""
+        classify = self._reload_google_no_api_core()
+        exc = Exception("rate limit exceeded for project")
+        result = classify(exc, "gemini-2.5-flash")
+        assert result.is_rate_limit is True
+        assert result.status_code == 429
+
+    def test_deadline_exceeded_sets_status_408_option_b(self):
+        """'deadline exceeded' in Option-B must set status_code=408."""
+        classify = self._reload_google_no_api_core()
+        exc = Exception("deadline exceeded waiting for response")
+        result = classify(exc, "gemini-2.5-flash")
+        assert result.status_code == 408
+        assert result.retryable is True
+
+    def test_deadline_exceeded_sets_status_408_option_a(self):
+        """DeadlineExceeded via typed Option-A path must set status_code=408."""
+        from types import SimpleNamespace
+        from unittest.mock import patch
+
+        fake_deadline_exceeded = type("DeadlineExceeded", (Exception,), {})
+        fake_resource_exhausted = type("ResourceExhausted", (Exception,), {})
+        fake_service_unavailable = type("ServiceUnavailable", (Exception,), {})
+
+        # Build a namespace that mirrors the subset of google.api_core.exceptions
+        # that _classify_google_exc uses, then patch _gax_exc in the module directly.
+        fake_gax = SimpleNamespace(
+            ResourceExhausted=fake_resource_exhausted,
+            ServiceUnavailable=fake_service_unavailable,
+            DeadlineExceeded=fake_deadline_exceeded,
+        )
+
+        from accrue.steps.providers import google as _google_mod
+
+        with patch.object(_google_mod, "_gax_exc", fake_gax):
+            exc = fake_deadline_exceeded("deadline exceeded")
+            result = _google_mod._classify_google_exc(exc, "gemini-2.5-flash")
+
+        assert result.status_code == 408
+        assert result.retryable is True


### PR DESCRIPTION
## Summary

Five small bug fixes bundled from the third-pass review (after PRs #66-#73).

- **Google regex**: word-boundary `_RATE_LIMIT_RE` replaces bare `"rate" in exc_str` — prevents false positives on "iterate", "accelerator", "rated"
- **408 status code**: `DeadlineExceeded` sets `status_code=408` in both Option-A (typed) and Option-B (substring) paths, matching the Anthropic adapter
- **Legacy checkpoint discard**: pre-1.2.1 `__type__` sentinel now triggers a `WARNING` and is discarded so pipelines resume cleanly instead of silently misreading typed values
- **Anthropic scope comment**: documents that `_warned_grounding_schema` is per-client-instance (once per run, not once per process)
- **Batch cancel warning**: cancel_batch failures after submit failure now log a `WARNING` so users know orphaned batches may still be billable

## Changes
- `accrue/steps/providers/google.py`: `_RATE_LIMIT_RE` regex + `status_code=408` on DeadlineExceeded (both paths)
- `accrue/core/checkpoint.py`: legacy `__type__` detection in `_typed_decoder`, separate `json.JSONDecodeError` catch in `load()`
- `accrue/steps/providers/anthropic.py`: comment on `_warned_grounding_schema` scope
- `accrue/pipeline/pipeline.py`: inspect `cancel_batch` gather results, warn on failures
- `CHANGELOG.md`: all five fixes documented under [Unreleased]

## Testing
- 598 tests pass (6 new tests)
- `ruff check` + `ruff format --check` both green

## Checklist
- [x] Lint passes
- [x] Tests pass
- [x] No evals framework in repo — skip
- [x] Labels: bug + priority:low from issue applied
- [x] Self-reviewed
- [x] No architectural decisions — no ADR needed

Closes #80