### PR TITLE
fix: NaN row values become None at DataFrame boundary

### DIFF
--- a/accrue/core/enricher.py
+++ b/accrue/core/enricher.py
@@ -129,8 +129,10 @@ class Enricher:
             checkpoint_results = dict(prior_step_results)
             logger.info(f"Resuming from checkpoint: skipping {completed_steps}")
 
-        # Convert DataFrame to rows
-        rows = df.to_dict(orient="records")
+        # Convert DataFrame to rows, replacing NaN/NaT/pd.NA with None.
+        # astype(object) is required first; otherwise float columns keep nan
+        # even after where(..., None) because pandas preserves dtype.
+        rows = df.astype(object).where(pd.notna(df), None).to_dict(orient="records")
 
         # Build on_step_complete callback for checkpointing
         cb_completed = list(completed_steps)

--- a/accrue/pipeline/pipeline.py
+++ b/accrue/pipeline/pipeline.py
@@ -338,7 +338,7 @@ class Pipeline:
             rows = data
             input_is_list = True
         else:
-            rows = data.to_dict(orient="records")
+            rows = data.astype(object).where(pd.notna(data), None).to_dict(orient="records")
             input_is_list = False
 
         # Set up cache manager

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -385,3 +385,89 @@ class TestMergeResultsIntoDf:
         accumulated = [{"b": "val"}]
         with pytest.raises(ValueError, match="duplicate column names"):
             _merge_results_into_df(df, accumulated, overwrite_fields=True)
+
+
+# -- NaN → None boundary conversion -----------------------------------------
+
+
+class TestNanToNoneBoundary:
+    """DataFrame → row dict conversion must replace NaN/NaT/pd.NA with None."""
+
+    def _make_pipeline(self, captured: list):
+        """Return a pipeline that appends ctx.row['x'] to *captured*."""
+
+        def fn(ctx: StepContext) -> dict[str, Any]:
+            captured.append(ctx.row["x"])
+            return {}
+
+        return Pipeline([FunctionStep("capture", fn=fn, fields=[])])
+
+    @pytest.mark.asyncio
+    async def test_float_nan_becomes_none(self):
+        """float('nan') in a DataFrame column is converted to None before step.run."""
+        captured: list = []
+        p = self._make_pipeline(captured)
+        df = pd.DataFrame({"x": [1.0, float("nan"), 3.0]})
+        await p.run_async(df)
+        assert captured[1] is None, f"expected None, got {captured[1]!r}"
+
+    @pytest.mark.asyncio
+    async def test_pd_na_becomes_none(self):
+        """pd.NA in a DataFrame column is converted to None before step.run."""
+        captured: list = []
+        p = self._make_pipeline(captured)
+        df = pd.DataFrame({"x": pd.array([1, pd.NA, 3], dtype="Int64")})
+        await p.run_async(df)
+        assert captured[1] is None, f"expected None, got {captured[1]!r}"
+
+    @pytest.mark.asyncio
+    async def test_nat_becomes_none(self):
+        """pd.NaT in a datetime column is converted to None before step.run."""
+        captured: list = []
+        p = self._make_pipeline(captured)
+        df = pd.DataFrame({"x": pd.to_datetime(["2024-01-01", None, "2024-03-01"])})
+        await p.run_async(df)
+        assert captured[1] is None, f"expected None, got {captured[1]!r}"
+
+    @pytest.mark.asyncio
+    async def test_none_roundtrips_as_none(self):
+        """An explicit Python None in input stays None after conversion."""
+        captured: list = []
+        p = self._make_pipeline(captured)
+        df = pd.DataFrame({"x": [1, None, 3]})
+        await p.run_async(df)
+        assert captured[1] is None, f"expected None, got {captured[1]!r}"
+
+    @pytest.mark.asyncio
+    async def test_run_if_predicate_is_falsy_for_nan_was_none(self):
+        """run_if lambda receives None (not nan) so the predicate evaluates falsy."""
+        skipped: list = []
+
+        def fn(ctx: StepContext) -> dict[str, Any]:
+            skipped.append(ctx.row["x"])
+            return {}
+
+        p = Pipeline(
+            [
+                FunctionStep(
+                    "conditional",
+                    fn=fn,
+                    fields=[],
+                    run_if=lambda row, _prior: row.get("x"),
+                )
+            ]
+        )
+        df = pd.DataFrame({"x": [1.0, float("nan"), 3.0]})
+        await p.run_async(df)
+        # Middle row should be skipped — None is falsy, nan is truthy
+        assert len(skipped) == 2
+        assert 1.0 in skipped and 3.0 in skipped
+
+    @pytest.mark.asyncio
+    async def test_non_null_dataframe_regression(self):
+        """Existing behaviour with fully-populated DataFrame is unchanged."""
+        captured: list = []
+        p = self._make_pipeline(captured)
+        df = pd.DataFrame({"x": [10, 20, 30]})
+        await p.run_async(df)
+        assert captured == [10, 20, 30]


### PR DESCRIPTION
## Summary

- `float('nan')`, `pd.NA`, and `pd.NaT` in input DataFrames were preserved when converted to row dicts, causing `nan` to appear truthy and render as `"nan"` in LLM prompts
- Applied `df.astype(object).where(pd.notna(df), None).to_dict(orient="records")` at both conversion sites (`accrue/pipeline/pipeline.py` and `accrue/core/enricher.py`); `astype(object)` is required before `where` because pandas preserves float dtype otherwise
- Added 6 tests in `TestNanToNoneBoundary`: `float('nan')`, `pd.NA`, `pd.NaT`, `None` round-trip, `run_if` predicate falsy-check, and non-null regression

## Test plan

- [x] All 6 NaN boundary tests pass
- [x] 616 total tests pass
- [x] ruff check and format clean

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)