### PR TITLE
perf(hooks): fire on_row_complete as background tasks, drain at step end (#76)

### DIFF
--- a/accrue/core/hooks.py
+++ b/accrue/core/hooks.py
@@ -7,6 +7,7 @@ failures never crash data pipelines.
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
 from dataclasses import dataclass
@@ -103,12 +104,17 @@ class EnrichmentHooks:
 
 
 async def _fire_hook(hook: Callable | None, event: Any) -> None:
-    """Call *hook* with *event*, awaiting if async.  Silently catches errors."""
+    """Call *hook* with *event*, awaiting if async.  Silently catches errors.
+
+    Sync hooks are dispatched via ``asyncio.to_thread`` so a blocking hook
+    (e.g. one that writes to Slack or Sentry) does not freeze the event loop.
+    """
     if hook is None:
         return
     try:
-        result = hook(event)
-        if inspect.isawaitable(result):
-            await result
+        if inspect.iscoroutinefunction(hook):
+            await hook(event)
+        else:
+            await asyncio.to_thread(hook, event)
     except Exception:
         logger.warning("Hook %s raised an exception", hook, exc_info=True)

--- a/accrue/pipeline/pipeline.py
+++ b/accrue/pipeline/pipeline.py
@@ -833,6 +833,7 @@ class Pipeline:
 
             tasks = [asyncio.create_task(tracked_row(i)) for i in range(num_rows)]
             completed_count = 0
+            hook_tasks: list[asyncio.Task] = []
             try:
                 for coro in asyncio.as_completed(tasks):
                     idx, result_or_none, exc = await coro
@@ -852,18 +853,23 @@ class Pipeline:
                             exc,
                         )
 
-                        # Fire on_row_complete for error
-                        await _fire_hook(
-                            hooks.on_row_complete,
-                            RowCompleteEvent(
-                                step_name=step.name,
-                                row_index=idx,
-                                values={f: None for f in step.fields},
-                                error=exc,
-                                from_cache=False,
-                                skipped=row_was_skipped[idx],
-                            ),
-                        )
+                        # Fire on_row_complete as background task (non-blocking)
+                        if hooks.on_row_complete:
+                            hook_tasks.append(
+                                asyncio.create_task(
+                                    _fire_hook(
+                                        hooks.on_row_complete,
+                                        RowCompleteEvent(
+                                            step_name=step.name,
+                                            row_index=idx,
+                                            values={f: None for f in step.fields},
+                                            error=exc,
+                                            from_cache=False,
+                                            skipped=row_was_skipped[idx],
+                                        ),
+                                    )
+                                )
+                            )
 
                         if on_error == "raise":
                             step_values[step.name] = results
@@ -872,35 +878,49 @@ class Pipeline:
                                 if not t.done():
                                     t.cancel()
                             await asyncio.gather(*tasks, return_exceptions=True)
+                            if hook_tasks:
+                                await asyncio.gather(*hook_tasks, return_exceptions=True)
                             raise exc
                     else:
                         results[idx] = result_or_none.values
                         if result_or_none.usage:
                             usage_list.append(result_or_none.usage)
 
-                        # Fire on_row_complete for success
-                        await _fire_hook(
-                            hooks.on_row_complete,
-                            RowCompleteEvent(
-                                step_name=step.name,
-                                row_index=idx,
-                                values=result_or_none.values,
-                                error=None,
-                                from_cache=row_from_cache[idx],
-                                skipped=row_was_skipped[idx],
-                            ),
-                        )
+                        # Fire on_row_complete as background task (non-blocking)
+                        if hooks.on_row_complete:
+                            hook_tasks.append(
+                                asyncio.create_task(
+                                    _fire_hook(
+                                        hooks.on_row_complete,
+                                        RowCompleteEvent(
+                                            step_name=step.name,
+                                            row_index=idx,
+                                            values=result_or_none.values,
+                                            error=None,
+                                            from_cache=row_from_cache[idx],
+                                            skipped=row_was_skipped[idx],
+                                        ),
+                                    )
+                                )
+                            )
 
                     completed_count += 1
                     row_bar.update(1)
                     if completed_count % checkpoint_interval == 0:
                         on_partial_checkpoint(step.name, results, completed_count)
+
+                # Drain all background hook tasks before the step is declared complete
+                if hook_tasks:
+                    await asyncio.gather(*hook_tasks, return_exceptions=True)
             except (asyncio.CancelledError, KeyboardInterrupt):
                 # Drain all in-flight tasks so they don't race teardown
                 for t in tasks:
                     if not t.done():
                         t.cancel()
                 await asyncio.gather(*tasks, return_exceptions=True)
+                # Drain hook tasks before re-raising
+                if hook_tasks:
+                    await asyncio.gather(*hook_tasks, return_exceptions=True)
                 # Persist whatever was accumulated so resume works
                 step_values[step.name] = results
                 if on_partial_checkpoint is not None and completed_count > 0:
@@ -915,6 +935,7 @@ class Pipeline:
                     return (idx, None, exc)
 
             tasks = [asyncio.create_task(_tracked_row(i)) for i in range(num_rows)]
+            hook_tasks_plain: list[asyncio.Task] = []
             for coro in asyncio.as_completed(tasks):
                 idx, result_or_none, exc = await coro
                 row_bar.update(1)
@@ -934,18 +955,23 @@ class Pipeline:
                         exc,
                     )
 
-                    # Fire on_row_complete for error
-                    await _fire_hook(
-                        hooks.on_row_complete,
-                        RowCompleteEvent(
-                            step_name=step.name,
-                            row_index=idx,
-                            values={f: None for f in step.fields},
-                            error=exc,
-                            from_cache=False,
-                            skipped=row_was_skipped[idx],
-                        ),
-                    )
+                    # Fire on_row_complete as background task (non-blocking)
+                    if hooks.on_row_complete:
+                        hook_tasks_plain.append(
+                            asyncio.create_task(
+                                _fire_hook(
+                                    hooks.on_row_complete,
+                                    RowCompleteEvent(
+                                        step_name=step.name,
+                                        row_index=idx,
+                                        values={f: None for f in step.fields},
+                                        error=exc,
+                                        from_cache=False,
+                                        skipped=row_was_skipped[idx],
+                                    ),
+                                )
+                            )
+                        )
 
                     if on_error == "raise":
                         step_values[step.name] = results
@@ -954,24 +980,35 @@ class Pipeline:
                             if not t.done():
                                 t.cancel()
                         await asyncio.gather(*tasks, return_exceptions=True)
+                        if hook_tasks_plain:
+                            await asyncio.gather(*hook_tasks_plain, return_exceptions=True)
                         raise exc
                 else:
                     results[idx] = result_or_none.values
                     if result_or_none.usage:
                         usage_list.append(result_or_none.usage)
 
-                    # Fire on_row_complete for success
-                    await _fire_hook(
-                        hooks.on_row_complete,
-                        RowCompleteEvent(
-                            step_name=step.name,
-                            row_index=idx,
-                            values=result_or_none.values,
-                            error=None,
-                            from_cache=row_from_cache[idx],
-                            skipped=row_was_skipped[idx],
-                        ),
-                    )
+                    # Fire on_row_complete as background task (non-blocking)
+                    if hooks.on_row_complete:
+                        hook_tasks_plain.append(
+                            asyncio.create_task(
+                                _fire_hook(
+                                    hooks.on_row_complete,
+                                    RowCompleteEvent(
+                                        step_name=step.name,
+                                        row_index=idx,
+                                        values=result_or_none.values,
+                                        error=None,
+                                        from_cache=row_from_cache[idx],
+                                        skipped=row_was_skipped[idx],
+                                    ),
+                                )
+                            )
+                        )
+
+            # Drain all background hook tasks before the step is declared complete
+            if hook_tasks_plain:
+                await asyncio.gather(*hook_tasks_plain, return_exceptions=True)
 
         row_bar.close()
 
@@ -1117,19 +1154,27 @@ class Pipeline:
                     execution_mode="batch",
                 )
 
-            # Fire hooks for cached/skipped rows
+            # Fire hooks for cached/skipped rows as background tasks, then drain
+            hook_tasks_cached: list[asyncio.Task] = []
             for idx in range(num_rows):
-                await _fire_hook(
-                    hooks.on_row_complete,
-                    RowCompleteEvent(
-                        step_name=step.name,
-                        row_index=idx,
-                        values=results[idx],
-                        error=None,
-                        from_cache=row_from_cache[idx],
-                        skipped=row_was_skipped[idx],
-                    ),
-                )
+                if hooks.on_row_complete:
+                    hook_tasks_cached.append(
+                        asyncio.create_task(
+                            _fire_hook(
+                                hooks.on_row_complete,
+                                RowCompleteEvent(
+                                    step_name=step.name,
+                                    row_index=idx,
+                                    values=results[idx],
+                                    error=None,
+                                    from_cache=row_from_cache[idx],
+                                    skipped=row_was_skipped[idx],
+                                ),
+                            )
+                        )
+                    )
+            if hook_tasks_cached:
+                await asyncio.gather(*hook_tasks_cached, return_exceptions=True)
 
             elapsed = _time.monotonic() - step_start
             return errors, step_usage, elapsed
@@ -1328,20 +1373,28 @@ class Pipeline:
         # ── Phase 7: Merge and finalize ────────────────────────────────
         step_values[step.name] = results
 
-        # Fire hooks for all rows
+        # Fire hooks for all rows as background tasks, then drain
+        hook_tasks_batch: list[asyncio.Task] = []
         for idx in range(num_rows):
-            error_obj = next((e.error for e in errors if e.row_index == idx), None)
-            await _fire_hook(
-                hooks.on_row_complete,
-                RowCompleteEvent(
-                    step_name=step.name,
-                    row_index=idx,
-                    values=results[idx],
-                    error=error_obj,
-                    from_cache=row_from_cache[idx],
-                    skipped=row_was_skipped[idx],
-                ),
-            )
+            if hooks.on_row_complete:
+                error_obj = next((e.error for e in errors if e.row_index == idx), None)
+                hook_tasks_batch.append(
+                    asyncio.create_task(
+                        _fire_hook(
+                            hooks.on_row_complete,
+                            RowCompleteEvent(
+                                step_name=step.name,
+                                row_index=idx,
+                                values=results[idx],
+                                error=error_obj,
+                                from_cache=row_from_cache[idx],
+                                skipped=row_was_skipped[idx],
+                            ),
+                        )
+                    )
+                )
+        if hook_tasks_batch:
+            await asyncio.gather(*hook_tasks_batch, return_exceptions=True)
 
         # Build step usage
         step_usage: StepUsage | None = None

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -300,3 +301,94 @@ class TestHooksIntegration:
         s2_events = [e for e in events if e.step_name == "s2"]
         assert len(s1_events) == 2
         assert len(s2_events) == 2
+
+
+# ---------------------------------------------------------------------------
+# Performance + correctness tests for fire-async, drain-at-step-end
+# ---------------------------------------------------------------------------
+
+
+class TestHooksFireAsync:
+    @pytest.mark.asyncio
+    async def test_sync_hook_with_delay_does_not_serialize(self):
+        """50 rows × 100ms sync hook must finish well under 5s total.
+
+        Without the fix each hook would be awaited sequentially, totalling ~5s.
+        With asyncio.to_thread + create_task they run concurrently and the wall
+        time should be ~0.1s + overhead (under 2s is a generous bound).
+        """
+
+        def slow_hook(event):
+            time.sleep(0.1)
+
+        hooks = EnrichmentHooks(on_row_complete=slow_hook)
+        pipeline = Pipeline([_MockStep("s1", fields=["f1"])])
+        rows = [{"x": i} for i in range(50)]
+
+        start = time.monotonic()
+        await pipeline.run_async(rows, hooks=hooks)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 2.0, f"Hooks appear to be serializing: {elapsed:.2f}s (want < 2s)"
+
+    @pytest.mark.asyncio
+    async def test_async_hook_drained_before_step_complete(self):
+        """Async hook with internal await must be fully awaited before step returns.
+
+        The hook appends a first entry, sleeps briefly, then appends a second.
+        Both entries must be present when the pipeline returns — if hooks were
+        fire-and-forget (not drained) only the first entry would be there.
+        """
+        log: list[str] = []
+
+        async def two_part_hook(event):
+            log.append(f"first:{event.row_index}")
+            await asyncio.sleep(0.01)
+            log.append(f"second:{event.row_index}")
+
+        hooks = EnrichmentHooks(on_row_complete=two_part_hook)
+        pipeline = Pipeline([_MockStep("s1", fields=["f1"])])
+        await pipeline.run_async([{"x": 0}, {"x": 1}], hooks=hooks)
+
+        first_entries = [e for e in log if e.startswith("first:")]
+        second_entries = [e for e in log if e.startswith("second:")]
+        assert len(first_entries) == 2, "Expected 2 'first' hook entries"
+        assert len(second_entries) == 2, "Expected 2 'second' hook entries (drain incomplete)"
+
+    @pytest.mark.asyncio
+    async def test_hook_exception_does_not_crash_pipeline(self):
+        """A hook that raises must not propagate to the pipeline caller."""
+
+        def crashing_hook(event):
+            raise RuntimeError("hook exploded in async path")
+
+        hooks = EnrichmentHooks(on_row_complete=crashing_hook)
+        pipeline = Pipeline([_MockStep("s1", fields=["f1"])])
+        rows = [{"x": i} for i in range(5)]
+
+        result = await pipeline.run_async(rows, hooks=hooks)
+        # Pipeline should complete with all rows present
+        assert len(result.data) == 5
+
+    @pytest.mark.asyncio
+    async def test_step_level_hooks_remain_serial(self):
+        """on_step_end for step 1 fires BEFORE on_step_start for step 2."""
+        log: list[str] = []
+
+        def on_start(e):
+            log.append(f"start:{e.step_name}")
+
+        def on_end(e):
+            log.append(f"end:{e.step_name}")
+
+        hooks = EnrichmentHooks(on_step_start=on_start, on_step_end=on_end)
+        pipeline = Pipeline(
+            [
+                _MockStep("s1", fields=["f1"]),
+                _MockStep("s2", fields=["f2"], depends_on=["s1"]),
+            ]
+        )
+        await pipeline.run_async([{"x": 1}], hooks=hooks)
+
+        # Strict ordering: start:s1, end:s1, start:s2, end:s2
+        assert log == ["start:s1", "end:s1", "start:s2", "end:s2"]


### PR DESCRIPTION
## Summary

Removes the per-row hook bottleneck that could turn a 1-hour pipeline into a 10-hour one when `on_row_complete` performs slow I/O (Slack, Sentry, Langfuse).

- `on_row_complete` hooks are now fired as `asyncio.create_task(...)` inside every `as_completed` consumer loop and drained via `asyncio.gather` before the step is declared complete
- Sync hook callables are wrapped in `asyncio.to_thread` inside `_fire_hook` so a blocking sync hook doesn't freeze the event loop
- Step/pipeline-level hooks (`on_step_start`, `on_step_end`, etc.) remain synchronously awaited — they fire once per step with no compounding cost
- Hook tasks are drained in cancellation `finally` blocks as well, so Ctrl-C doesn't race teardown

## Changes

- `accrue/core/hooks.py`: wrap sync callables in `asyncio.to_thread` inside `_fire_hook`
- `accrue/pipeline/pipeline.py`: replace `await _fire_hook(hooks.on_row_complete, ...)` with `asyncio.create_task(...)` at all 4 per-row call sites (realtime checkpoint, realtime plain, batch early-exit, batch Phase 7); drain with `asyncio.gather` at step end and in cancellation path
- `tests/test_hooks.py`: 4 new tests — sync-hook concurrency timing bound, async drain completeness, hook exception resilience, step-level serial ordering

## Testing

- 620 tests pass (`pytest -x -q --ignore=tests/integration`)
- `ruff check accrue/ tests/` — clean
- `ruff format --check accrue/ tests/` — clean
- New test `test_sync_hook_with_delay_does_not_serialize`: 50 rows × 100ms sync hook completes under 2s (was ~5s)
- New test `test_async_hook_drained_before_step_complete`: two-part async hook both entries present after pipeline returns

## Checklist
- [x] Lint passes
- [x] Tests pass
- [x] No evals needed — internal scheduling change with no behavioral effect on output
- [x] Labels copied from source issue applied
- [x] Self-reviewed
- [x] ADR not required — additive pattern change, no new dependencies

Closes #76