### PR TITLE
release: bump version to 1.3.0

### DIFF
--- a/accrue/__init__.py
+++ b/accrue/__init__.py
@@ -35,7 +35,7 @@ from .steps.providers.base import BatchCapableLLMClient, BatchRequest, BatchResu
 from .utils.logger import setup_logging
 from .utils.web_search import web_search
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 __author__ = "Accrue Team"
 
 __all__ = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "accrue"
-version = "1.2.0"
+version = "1.3.0"
 authors = [
   { name="Matthew House", email="matt.house.e@gmail.com" },
 ]


### PR DESCRIPTION
## Summary

Version bump 1.2.0 → 1.3.0 in preparation for PyPI release.

## Why minor, not patch

Per strict semver, two behavior changes since v1.2.0 warrant a minor bump even though every individual change is a bugfix or quality improvement:

- Default `cache_dir` changed from cwd-relative `.accrue/` to `${XDG_CACHE_HOME:-~/.cache}/accrue`. Same for `checkpoint_dir` (XDG_STATE_HOME).
- Checkpoint typed-sentinel renamed `__type__` → `__accrue_type__`; pre-1.3 files with datetime/Decimal/set values are detected and discarded (with warning), forcing a re-run.

Plus other observable-behavior changes: import-time `load_dotenv()` and `setup_logging()` removed; native SDK retry disabled (`max_retries=0`); web_search wraps content in per-call random boundary token; refusal detection no longer overrides legitimate enum values.

## Test plan

- `pytest -x -q` all green on main at 846c2c9 (the commit this branches from)
- `ruff check` + `ruff format --check` clean

After merge: tag `v1.3.0` triggers the publish workflow (OIDC → PyPI).