### PR TITLE
feat: auto-save results to file on pipeline completion (#10)

### DIFF
--- a/accrue/pipeline/pipeline.py
+++ b/accrue/pipeline/pipeline.py
@@ -6,6 +6,7 @@ import asyncio
 import inspect
 import time as _time
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Callable
 
 import pandas as pd
@@ -285,10 +286,55 @@ class PipelineResult:
             )
 
         if path is not None:
-            from pathlib import Path
-
             Path(path).write_text(text, encoding="utf-8")
         return text
+
+    def save(self, path: str | Path) -> Path:
+        """Persist the enriched data to disk, inferring format from the extension.
+
+        Supported extensions: ``.csv``, ``.json``, ``.parquet``.  Parent
+        directories are created if they don't exist.
+
+        This is what ``Pipeline.run(..., output_file=...)`` calls internally,
+        before ``run`` returns — so a crash in your own post-processing can't
+        lose a completed (and already paid-for) run.  Calling it yourself is
+        handy when you want to save conditionally or to multiple formats.
+
+        Args:
+            path: Destination file.  The suffix selects the writer
+                (``.csv`` / ``.json`` / ``.parquet``).
+
+        Returns:
+            The :class:`~pathlib.Path` that was written.
+
+        Raises:
+            ValueError: If the extension isn't one of the supported formats.
+            ImportError: If ``.parquet`` is requested but no parquet engine
+                (e.g. pyarrow) is installed.
+        """
+        dest = Path(path)
+        suffix = dest.suffix.lower()
+        df = self.data if isinstance(self.data, pd.DataFrame) else pd.DataFrame(self.data)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+
+        if suffix == ".csv":
+            df.to_csv(dest, index=False)
+        elif suffix == ".json":
+            df.to_json(dest, orient="records", indent=2)
+        elif suffix == ".parquet":
+            try:
+                df.to_parquet(dest, index=False)
+            except ImportError as exc:
+                raise ImportError(
+                    "Writing .parquet requires a parquet engine; "
+                    "install one with `pip install pyarrow`."
+                ) from exc
+        else:
+            raise ValueError(
+                f"Cannot infer output format from {dest.name!r}; "
+                "expected a .csv, .json, or .parquet extension."
+            )
+        return dest
 
 
 class Pipeline:
@@ -352,10 +398,16 @@ class Pipeline:
         data: pd.DataFrame | list[dict[str, Any]],
         config: EnrichmentConfig | None = None,
         hooks: EnrichmentHooks | None = None,
+        output_file: str | Path | None = None,
     ) -> PipelineResult:
         """Synchronous entry point — the ONE way to use Accrue.
 
         Accepts a DataFrame or ``list[dict]``. Output type matches input type.
+
+        If ``output_file`` is given, the enriched data is written to it (format
+        inferred from the extension — ``.csv`` / ``.json`` / ``.parquet``) before
+        ``run`` returns, so an error in your own post-processing can't lose a
+        completed, paid-for run.  ``result.data`` is still returned in memory.
 
         Raises ``RuntimeError`` if called from inside a running event loop
         (use ``await pipeline.run_async(data)`` in that case).
@@ -369,13 +421,14 @@ class Pipeline:
         except RuntimeError as exc:
             if "run_async" in str(exc):
                 raise
-        return asyncio.run(self.run_async(data, config, hooks=hooks))
+        return asyncio.run(self.run_async(data, config, hooks=hooks, output_file=output_file))
 
     async def run_async(
         self,
         data: pd.DataFrame | list[dict[str, Any]],
         config: EnrichmentConfig | None = None,
         hooks: EnrichmentHooks | None = None,
+        output_file: str | Path | None = None,
     ) -> PipelineResult:
         """Async entry point — ``await pipeline.run_async(data)``.
 
@@ -387,6 +440,11 @@ class Pipeline:
                 for most workloads.
             hooks: Optional :class:`EnrichmentHooks` for lifecycle callbacks
                 (pipeline start/end, step start/end, row complete).
+            output_file: If given, the enriched data is saved here (format
+                inferred from the extension — ``.csv`` / ``.json`` /
+                ``.parquet``) before this method returns, guarding a completed
+                run against errors in downstream user code.  See
+                :meth:`PipelineResult.save`.
 
         Returns:
             A :class:`PipelineResult` containing the enriched data, aggregated
@@ -465,7 +523,7 @@ class Pipeline:
                     if not key.startswith("__"):
                         merged[key] = value
                 result_rows.append(merged)
-            return PipelineResult(
+            result = PipelineResult(
                 data=result_rows,
                 cost=cost,
                 errors=errors,
@@ -475,7 +533,7 @@ class Pipeline:
             )
         else:
             df_out = self._build_result_df(data, accumulated, config)
-            return PipelineResult(
+            result = PipelineResult(
                 data=df_out,
                 cost=cost,
                 errors=errors,
@@ -483,6 +541,12 @@ class Pipeline:
                 step_elapsed_seconds=step_elapsed,
                 field_specs=all_fields,
             )
+
+        # Persist before returning so downstream user errors can't lose a
+        # completed run (see issue #10).
+        if output_file is not None:
+            result.save(output_file)
+        return result
 
     def runner(self, config: EnrichmentConfig | None = None) -> Any:
         """Create a reusable :class:`Enricher` runner for this pipeline.

--- a/docs/getting-started/core-concepts.md
+++ b/docs/getting-started/core-concepts.md
@@ -33,3 +33,14 @@ OpenAI is the default provider and requires no extra configuration. Anthropic an
 ## Results
 
 `Pipeline.run()` returns a `PipelineResult` containing enriched data, cost information, and any errors. The output type matches the input type: pass in a DataFrame and get a DataFrame back, pass in a list of dicts and get a list of dicts back. `CostSummary` breaks down token usage and cache hit rates per step.
+
+## Saving results
+
+A finished pipeline run has already cost you tokens and time, so don't let a typo in your own save logic throw it away. Pass `output_file` to `run()` (or `run_async()`) and the enriched data is written to disk **before `run()` returns** — the format is inferred from the extension (`.csv`, `.json`, or `.parquet`):
+
+```python
+result = pipeline.run(data, output_file="output/results.csv")
+# results are already on disk; result.data is still in memory as usual
+```
+
+`result.data` is still returned in memory exactly as before. You can also persist on demand with `result.save("output/results.json")` — handy for writing multiple formats or saving conditionally. Writing `.parquet` requires a parquet engine (`pip install pyarrow`).

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -1,0 +1,129 @@
+"""Tests for auto-saving pipeline results to disk (issue #10)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from accrue.pipeline.pipeline import Pipeline, PipelineResult
+from accrue.steps.base import StepContext
+from accrue.steps.function import FunctionStep
+
+# -- helpers -------------------------------------------------------------
+
+
+def _echo_step() -> FunctionStep:
+    """A FunctionStep that writes a constant field, so runs are deterministic."""
+
+    def fn(ctx: StepContext) -> dict[str, Any]:
+        return {"v": ctx.row["i"] * 2}
+
+    return FunctionStep("double", fn=fn, fields=["v"])
+
+
+# -- PipelineResult.save() -----------------------------------------------
+
+
+class TestSaveFormats:
+    def test_csv_from_dataframe(self, tmp_path):
+        result = PipelineResult(data=pd.DataFrame({"a": [1, 2], "b": ["x", "y"]}))
+        dest = result.save(tmp_path / "out.csv")
+
+        assert dest.exists()
+        back = pd.read_csv(dest)
+        assert list(back["a"]) == [1, 2]
+        assert list(back["b"]) == ["x", "y"]
+
+    def test_csv_from_list_of_dicts(self, tmp_path):
+        result = PipelineResult(data=[{"a": 1, "b": "x"}, {"a": 2, "b": "y"}])
+        dest = result.save(tmp_path / "out.csv")
+
+        back = pd.read_csv(dest)
+        assert list(back["a"]) == [1, 2]
+
+    def test_json_round_trips(self, tmp_path):
+        result = PipelineResult(data=[{"a": 1, "b": "x"}, {"a": 2, "b": "y"}])
+        dest = result.save(tmp_path / "out.json")
+
+        loaded = json.loads(dest.read_text())
+        assert loaded == [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]
+
+    def test_parquet_round_trips(self, tmp_path):
+        pytest.importorskip("pyarrow")
+        result = PipelineResult(data=pd.DataFrame({"a": [1, 2], "b": ["x", "y"]}))
+        dest = result.save(tmp_path / "out.parquet")
+
+        back = pd.read_parquet(dest)
+        assert list(back["a"]) == [1, 2]
+
+    def test_extension_is_case_insensitive(self, tmp_path):
+        result = PipelineResult(data=[{"a": 1}])
+        dest = result.save(tmp_path / "out.CSV")
+        assert dest.exists()
+
+    def test_creates_parent_directories(self, tmp_path):
+        result = PipelineResult(data=[{"a": 1}])
+        dest = result.save(tmp_path / "nested" / "deeper" / "out.csv")
+        assert dest.exists()
+
+    def test_returns_written_path(self, tmp_path):
+        result = PipelineResult(data=[{"a": 1}])
+        target = tmp_path / "out.csv"
+        assert result.save(target) == target
+
+    def test_unknown_extension_raises(self, tmp_path):
+        result = PipelineResult(data=[{"a": 1}])
+        with pytest.raises(ValueError, match="csv.*json.*parquet"):
+            result.save(tmp_path / "out.xlsx")
+
+    def test_no_extension_raises(self, tmp_path):
+        result = PipelineResult(data=[{"a": 1}])
+        with pytest.raises(ValueError):
+            result.save(tmp_path / "out")
+
+
+# -- run(output_file=...) integration ------------------------------------
+
+
+class TestRunOutputFile:
+    def test_run_writes_file_and_keeps_data_in_memory(self, tmp_path):
+        dest = tmp_path / "results.csv"
+        pipeline = Pipeline([_echo_step()])
+        result = pipeline.run([{"i": 1}, {"i": 2}, {"i": 3}], output_file=dest)
+
+        # In-memory result is unchanged
+        assert [r["v"] for r in result.data] == [2, 4, 6]
+        # File was written with the same enriched values
+        back = pd.read_csv(dest)
+        assert list(back["v"]) == [2, 4, 6]
+
+    def test_run_without_output_file_writes_nothing(self, tmp_path):
+        pipeline = Pipeline([_echo_step()])
+        pipeline.run([{"i": 1}])
+        written = [
+            p for p in tmp_path.rglob("*") if p.suffix.lower() in {".csv", ".json", ".parquet"}
+        ]
+        assert written == []
+
+    def test_run_async_writes_file(self, tmp_path):
+        import asyncio
+
+        dest = tmp_path / "results.json"
+        pipeline = Pipeline([_echo_step()])
+        result = asyncio.run(pipeline.run_async([{"i": 5}], output_file=dest))
+
+        assert result.data[0]["v"] == 10
+        loaded = json.loads(dest.read_text())
+        assert loaded[0]["v"] == 10
+
+    def test_run_saves_before_returning(self, tmp_path):
+        """The save must happen inside run(), so a later user error can't lose it."""
+        dest = tmp_path / "results.csv"
+        pipeline = Pipeline([_echo_step()])
+        result = pipeline.run([{"i": 2}], output_file=dest)
+        # File already exists by the time run() returns — before any user code runs.
+        assert dest.exists()
+        assert result.data[0]["v"] == 4


### PR DESCRIPTION
## Summary
Adds an `output_file` parameter to `Pipeline.run()` / `run_async()` that persists the enriched data to disk **before `run()` returns**, plus a `PipelineResult.save(path)` convenience method. A completed run has already cost tokens and wall-time; today a typo in the caller's own save logic (`result.data.to_dict()` with the wrong attr, etc.) throws all of it away. This closes that gap. Closes #10.

## Changes
- **`PipelineResult.save(path)`** — normalizes `data` (DataFrame or `list[dict]`) and writes it, inferring format from the extension:
  - `.csv` → `to_csv(index=False)`, `.json` → `to_json(orient="records", indent=2)`, `.parquet` → `to_parquet`.
  - Creates parent directories; case-insensitive extension; returns the written `Path`.
  - Clear `ValueError` for an unsupported/missing extension; clear `ImportError` (→ `pip install pyarrow`) if a parquet engine is absent.
- **`output_file=` on `run()` / `run_async()`** — when set, calls `result.save(output_file)` inside `run()` before returning. Default `None` = current memory-only behaviour, unchanged. `result.data` is still returned in memory.
- Hoisted `from pathlib import Path` to module scope (annotations need it under `from __future__ import annotations`).
- **Docs**: new "Saving results" section in `docs/getting-started/core-concepts.md`.

## Testing
- New `tests/test_save.py` (12 tests): CSV/JSON/Parquet round-trips from both DataFrame and `list[dict]` results; parent-dir creation; case-insensitive + unknown-extension errors; `run()`/`run_async()` integration; and an explicit "file exists by the time `run()` returns" check.
- Full suite: **664 passed, 1 skipped** (parquet skips when no engine is installed — `pytest.importorskip`).
- `ruff check .` clean; `ruff format --check .` clean.

## Checklist
- [x] Lint + format pass
- [x] Tests pass
- [x] Labels copied from source issue + AI attribution
- [x] Self-reviewed
- [ ] No eval framework in this repo — N/A

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)