### PR TITLE
ci: make Claude PR review cheaper + fork-safe

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,16 +1,26 @@
 name: Claude PR review
 
-# Auto-runs an agent review on every PR opened or updated against main.
-# Uses the action's inline-comment MCP tool so feedback lands as inline
-# review comments (not a wall of text). track_progress posts a single
-# tracking comment with visual progress as the review runs.
+# Auto-runs an agent review when a PR is opened against main (and when a
+# draft is marked ready). Uses the action's inline-comment MCP tool so
+# feedback lands as inline review comments (not a wall of text).
+# track_progress posts a single tracking comment with visual progress.
+#
+# Cost control: each review costs ~$0.30, so we deliberately omit
+# `synchronize` — the review runs once per PR, not on every push. Re-run
+# it on demand after addressing feedback by commenting `@claude review`.
+# `paths-ignore` skips docs-only PRs that don't need a code review.
 #
 # Patterns from: https://github.com/anthropics/claude-code-action/blob/main/docs/solutions.md
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - "LICENSE"
+      - ".gitignore"
 
 # Only review the latest push if the PR is updated mid-review.
 concurrency:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,7 +19,14 @@ concurrency:
 
 jobs:
   review:
-    if: github.event.pull_request.draft == false
+    # Skip fork PRs: GitHub withholds secrets and the OIDC id-token from
+    # `pull_request` runs on forks, so the action can't auth (empty
+    # ANTHROPIC_API_KEY + failed OIDC token) and the job hard-fails with a
+    # red X. Gating here makes fork PRs skip the review instead. Maintainers
+    # can still review a fork PR on demand via the `@claude` mention bot.
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Three fixes to the **Claude PR review** workflow, all aimed at the red X / cost it was generating.

## 1. Skip fork PRs (the red X)
Fork PRs (e.g. #91) hard-failed after ~25s: GitHub withholds secrets and the OIDC id-token from `pull_request` runs on forks, so the action got an empty `ANTHROPIC_API_KEY` and couldn't exchange an OIDC token. The test matrix passed (no secrets needed), leaving a lone red review check.

Gate the job to same-repo PRs:
```yaml
if: >-
  github.event.pull_request.draft == false &&
  github.event.pull_request.head.repo.full_name == github.repository
```
Fork PRs now **skip** the review (neutral check, no red X). Fork contributors can still get a review on demand via `@claude review`.

## 2. Review once per PR, not on every push
Each review costs **~$0.30** (Sonnet, ~12 turns). The trigger included `synchronize`, so a PR pushed to N times was reviewed N times. Dropped `synchronize` → review runs once on open / ready-for-review. Re-run on demand with `@claude review` after addressing feedback.

## 3. Skip docs-only PRs
Added `paths-ignore` for `**/*.md`, `docs/**`, `LICENSE`, `.gitignore` so documentation-only PRs don't spend a review.

---
**Notes**
- The review check is red on *this* PR only — the action validates that the workflow file matches the version on `main`, which always fails when a PR edits the review workflow. It clears on merge. Not a required check, so merge isn't blocked.
- Required checks: `test (3.10–3.13)` — green.
- Unrelated context surfaced while debugging: the historical "all PRs failing" was an Anthropic **credit balance too low** error on the API key (now resolved — recent same-repo runs pass). No credential is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)