### PR TITLE
feat(pipeline): accrue.compare(result_a, result_b) — diff two pipeline runs (#36)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ result = pipeline.run(companies_df)
 
 - **Hooks** -- Typed lifecycle events for observability. Sync and async callables, never crash the pipeline. [Hooks guide](docs/guides/hooks.md)
 
+- **Run diffs** -- `accrue.compare(result_a, result_b)` diffs two runs (e.g. before/after a prompt tweak) -- changed rows, per-field churn, distribution shift, and cost delta -- no labels needed. [Compare guide](docs/guides/compare.md)
+
 - **`provider_kwargs`** -- Escape hatch for provider-specific features (extended thinking, effort control, etc.) without waiting for first-class support.
 
 ## Sweet Spot

--- a/accrue/__init__.py
+++ b/accrue/__init__.py
@@ -26,7 +26,14 @@ from .core.hooks import (
     StepEndEvent,
     StepStartEvent,
 )
-from .pipeline import Pipeline, PipelinePlan, PipelineResult, StepPlan
+from .pipeline import (
+    ComparisonResult,
+    Pipeline,
+    PipelinePlan,
+    PipelineResult,
+    StepPlan,
+    compare,
+)
 from .schemas.base import CostSummary
 from .schemas.field_spec import FieldSpec
 from .schemas.grounding import GroundingConfig
@@ -47,6 +54,8 @@ __all__ = [
     "LLMStep",
     "FunctionStep",
     "EnrichmentConfig",
+    "compare",
+    "ComparisonResult",
     # Hooks
     "EnrichmentHooks",
     "PipelineStartEvent",

--- a/accrue/pipeline/__init__.py
+++ b/accrue/pipeline/__init__.py
@@ -1,6 +1,14 @@
 """Pipeline execution engine for the Accrue enrichment engine."""
 
+from .compare import ComparisonResult, compare
 from .pipeline import Pipeline, PipelineResult
 from .plan import PipelinePlan, StepPlan
 
-__all__ = ["Pipeline", "PipelineResult", "PipelinePlan", "StepPlan"]
+__all__ = [
+    "Pipeline",
+    "PipelineResult",
+    "PipelinePlan",
+    "StepPlan",
+    "compare",
+    "ComparisonResult",
+]

--- a/accrue/pipeline/compare.py
+++ b/accrue/pipeline/compare.py
@@ -18,7 +18,7 @@ import json
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import pandas as pd
 
@@ -44,7 +44,9 @@ def _is_default_range_index(idx: pd.Index) -> bool:
     return isinstance(idx, pd.RangeIndex) and idx.equals(pd.RangeIndex(len(idx)))
 
 
-def _align_rows(df_a: pd.DataFrame, df_b: pd.DataFrame) -> tuple[list[int], list[int], str]:
+def _align_rows(
+    df_a: pd.DataFrame, df_b: pd.DataFrame
+) -> tuple[list[int], list[int], Literal["positional", "label"]]:
     """Pair up rows of *df_a* and *df_b* for comparison.
 
     Returns ``(positions_a, positions_b, mode)`` where ``positions_a[i]``
@@ -196,7 +198,7 @@ class FieldChurn:
     """
 
     field: str
-    kind: str
+    kind: Literal["enum", "numeric", "text"]
     changed: int
     total: int
     freq_a: dict[str, float] | None = None
@@ -260,18 +262,21 @@ def _format_header(label_a: str, cost_a: Any, label_b: str, cost_b: Any) -> str:
     return f"Comparing `{label_a}` ({_models_str(cost_a)}) vs. `{label_b}` ({_models_str(cost_b)})"
 
 
-def _format_enum_shift(fc: FieldChurn, limit: int = 5) -> str:
+_ENUM_SHIFT_LIMIT = 5
+
+
+def _format_enum_shift(fc: FieldChurn) -> str:
     """'<value>' <pctA>% → <pctB>%' for the values with the largest shift, biggest first."""
     freq_a, freq_b = fc.freq_a or {}, fc.freq_b or {}
     keys = sorted(set(freq_a) | set(freq_b))
     if not keys:
         return ""
     ranked = sorted(keys, key=lambda k: abs(freq_b.get(k, 0.0) - freq_a.get(k, 0.0)), reverse=True)
-    shown = ranked[:limit]
+    shown = ranked[:_ENUM_SHIFT_LIMIT]
     parts = [
         f"{k!r} {freq_a.get(k, 0.0) * 100:.0f}% → {freq_b.get(k, 0.0) * 100:.0f}%" for k in shown
     ]
-    if len(ranked) > limit:
+    if len(ranked) > _ENUM_SHIFT_LIMIT:
         parts.append("…")
     return ", ".join(parts)
 
@@ -362,7 +367,7 @@ class ComparisonResult:
     field_specs: dict[str, dict[str, Any]]
     aligned_a: pd.DataFrame
     aligned_b: pd.DataFrame
-    align_mode: str
+    align_mode: Literal["positional", "label"]
     pos_a: list[int]
     pos_b: list[int]
 
@@ -524,6 +529,12 @@ class ComparisonResult:
             elapsed_seconds_delta=elapsed_b - elapsed_a,
         )
 
+    def _row_counts(self) -> tuple[int, int, int]:
+        """``(total, changed, identical)`` aligned-row counts."""
+        total = len(self.aligned_a)
+        changed_n = len(self.changed_rows())
+        return total, changed_n, total - changed_n
+
     def summary(self) -> str:
         """Markdown summary — headline numbers, per-field churn, cost delta.
 
@@ -531,9 +542,7 @@ class ComparisonResult:
         Slack/GitHub. Identical runs short-circuit to a one-line "no
         differences" message instead of an empty churn/cost section.
         """
-        total = len(self.aligned_a)
-        changed_n = len(self.changed_rows())
-        identical_n = total - changed_n
+        total, changed_n, identical_n = self._row_counts()
 
         lines: list[str] = [
             "# Pipeline Comparison Report",
@@ -596,9 +605,7 @@ class ComparisonResult:
 
     def _render_html(self) -> str:
         """Self-contained HTML rendering of the same content as :meth:`summary`."""
-        total = len(self.aligned_a)
-        changed_n = len(self.changed_rows())
-        identical_n = total - changed_n
+        total, changed_n, identical_n = self._row_counts()
 
         header = _format_header(self.label_a, self.result_a.cost, self.label_b, self.result_b.cost)
         parts: list[str] = [

--- a/accrue/pipeline/compare.py
+++ b/accrue/pipeline/compare.py
@@ -163,6 +163,57 @@ def _value_counts_safe(series: pd.Series) -> pd.Series:
     return pd.Series(stringified, dtype=object).value_counts()
 
 
+def _frequency_table(series: pd.Series) -> dict[str, float]:
+    """value -> fraction of non-null rows, for an enum/categorical column."""
+    counts = _value_counts_safe(series)
+    total = int(counts.sum())
+    if total == 0:
+        return {}
+    return {str(k): v / total for k, v in counts.items()}
+
+
+# ---------------------------------------------------------------------------
+# Per-field churn
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FieldChurn:
+    """Before/after churn for a single output field.
+
+    ``kind`` selects which of the type-specific attributes are populated:
+
+    - ``"enum"``: ``freq_a``/``freq_b`` — value -> fraction frequency
+      tables.
+    - ``"numeric"``: ``mean_a``/``mean_b``/``std_a``/``std_b``/``mean_delta``.
+    - ``"text"``: ``avg_len_tokens_a``/``avg_len_tokens_b``/``len_delta_tokens``
+      (populated only for ``type: String``; ``None`` for Boolean/Date/JSON/
+      List[String], which only get a differs-count).
+
+    Numeric fields with no coercible values, or text fields with no rows,
+    leave their type-specific attributes as ``None`` rather than raising.
+    """
+
+    field: str
+    kind: str
+    changed: int
+    total: int
+    freq_a: dict[str, float] | None = None
+    freq_b: dict[str, float] | None = None
+    mean_a: float | None = None
+    mean_b: float | None = None
+    std_a: float | None = None
+    std_b: float | None = None
+    mean_delta: float | None = None
+    avg_len_tokens_a: float | None = None
+    avg_len_tokens_b: float | None = None
+    len_delta_tokens: float | None = None
+
+    @property
+    def changed_pct(self) -> float:
+        return (self.changed / self.total * 100) if self.total else 0.0
+
+
 # ---------------------------------------------------------------------------
 # compare() + ComparisonResult
 # ---------------------------------------------------------------------------
@@ -258,6 +309,77 @@ class ComparisonResult:
         after = self.aligned_b.loc[changed_idx, target_fields].add_suffix(suffix_b)
         ordered_cols = [c for f in target_fields for c in (f + suffix_a, f + suffix_b)]
         return pd.concat([before, after], axis=1)[ordered_cols]
+
+    def distribution_shift(self) -> dict[str, FieldChurn]:
+        """Per-field churn, classified by each field's spec.
+
+        - Enum fields (``spec["enum"]`` truthy): before/after frequency
+          tables.
+        - Numeric fields (``spec["type"] == "Number"``): mean/std and the
+          mean delta, coercing with ``pd.to_numeric(errors="coerce")`` so
+          stray non-numeric values don't raise.
+        - Everything else (String/Boolean/Date/JSON/List[String]): a
+          differs-count; String fields additionally get an approximate
+          token-length delta (``len(str(v)) // 4``, matching ``report.py``'s
+          length-anomaly heuristic).
+
+        Returns:
+            ``field name -> FieldChurn``, in the same order as ``.fields``.
+        """
+        result: dict[str, FieldChurn] = {}
+        n = len(self.aligned_a)
+        for f in self.fields:
+            spec = self.field_specs.get(f, {})
+            series_a, series_b = self.aligned_a[f], self.aligned_b[f]
+            vals_a, vals_b = series_a.tolist(), series_b.tolist()
+            changed = sum(1 for x, y in zip(vals_a, vals_b) if not _cells_equal(x, y))
+
+            if spec.get("enum"):
+                result[f] = FieldChurn(
+                    field=f,
+                    kind="enum",
+                    changed=changed,
+                    total=n,
+                    freq_a=_frequency_table(series_a),
+                    freq_b=_frequency_table(series_b),
+                )
+            elif spec.get("type") == "Number":
+                num_a = pd.to_numeric(series_a, errors="coerce")
+                num_b = pd.to_numeric(series_b, errors="coerce")
+                mean_a = float(num_a.mean()) if num_a.notna().any() else None
+                mean_b = float(num_b.mean()) if num_b.notna().any() else None
+                std_a = float(num_a.std()) if num_a.notna().sum() > 1 else None
+                std_b = float(num_b.std()) if num_b.notna().sum() > 1 else None
+                mean_delta = mean_b - mean_a if mean_a is not None and mean_b is not None else None
+                result[f] = FieldChurn(
+                    field=f,
+                    kind="numeric",
+                    changed=changed,
+                    total=n,
+                    mean_a=mean_a,
+                    mean_b=mean_b,
+                    std_a=std_a,
+                    std_b=std_b,
+                    mean_delta=mean_delta,
+                )
+            else:
+                len_a = len_b = len_delta = None
+                if spec.get("type", "String") == "String":
+                    lens_a = [len(str(v)) // 4 for v in vals_a if not _is_null(v)]
+                    lens_b = [len(str(v)) // 4 for v in vals_b if not _is_null(v)]
+                    len_a = sum(lens_a) / len(lens_a) if lens_a else None
+                    len_b = sum(lens_b) / len(lens_b) if lens_b else None
+                    len_delta = len_b - len_a if len_a is not None and len_b is not None else None
+                result[f] = FieldChurn(
+                    field=f,
+                    kind="text",
+                    changed=changed,
+                    total=n,
+                    avg_len_tokens_a=len_a,
+                    avg_len_tokens_b=len_b,
+                    len_delta_tokens=len_delta,
+                )
+        return result
 
 
 def compare(

--- a/accrue/pipeline/compare.py
+++ b/accrue/pipeline/compare.py
@@ -215,6 +215,50 @@ class ComparisonResult:
     pos_a: list[int]
     pos_b: list[int]
 
+    def changed_rows(self, field: str | None = None) -> pd.DataFrame:
+        """Before/after values for aligned rows that changed.
+
+        Args:
+            field: If given, only consider this output field (must be in
+                ``.fields``). If ``None`` (default), a row counts as
+                changed if *any* compared field differs.
+
+        Returns:
+            A DataFrame indexed by aligned-row position, with two columns
+            per considered field: ``"{field}_{label_a}"`` and
+            ``"{field}_{label_b}"``. Empty if nothing changed.
+
+        A row that errored on exactly one side counts as changed even if
+        its (typically ``None``-filled) values happen to compare equal —
+        an error means that side's output for the row isn't trustworthy,
+        independent of which field you're filtering to.
+        """
+        if field is not None and field not in self.fields:
+            raise KeyError(f"{field!r} is not a comparable output field; available: {self.fields}")
+        target_fields = [field] if field is not None else self.fields
+
+        error_pos_a = {e.row_index for e in self.result_a.errors}
+        error_pos_b = {e.row_index for e in self.result_b.errors}
+
+        col_a = {f: self.aligned_a[f].tolist() for f in target_fields}
+        col_b = {f: self.aligned_b[f].tolist() for f in target_fields}
+
+        changed_idx: list[int] = []
+        for i in range(len(self.aligned_a)):
+            errored_a = self.pos_a[i] in error_pos_a
+            errored_b = self.pos_b[i] in error_pos_b
+            if errored_a != errored_b:
+                changed_idx.append(i)
+                continue
+            if any(not _cells_equal(col_a[f][i], col_b[f][i]) for f in target_fields):
+                changed_idx.append(i)
+
+        suffix_a, suffix_b = f"_{self.label_a}", f"_{self.label_b}"
+        before = self.aligned_a.loc[changed_idx, target_fields].add_suffix(suffix_a)
+        after = self.aligned_b.loc[changed_idx, target_fields].add_suffix(suffix_b)
+        ordered_cols = [c for f in target_fields for c in (f + suffix_a, f + suffix_b)]
+        return pd.concat([before, after], axis=1)[ordered_cols]
+
 
 def compare(
     a: PipelineResult,

--- a/accrue/pipeline/compare.py
+++ b/accrue/pipeline/compare.py
@@ -22,7 +22,7 @@ from typing import Any
 import pandas as pd
 
 from .pipeline import PipelineResult
-from .report import _is_null
+from .report import _format_seconds, _format_tokens, _is_null
 
 __all__ = ["compare", "ComparisonResult"]
 
@@ -241,6 +241,79 @@ class CostDelta:
 
 
 # ---------------------------------------------------------------------------
+# Text fragments shared by summary() (Markdown) and report() (HTML)
+#
+# Each of these returns plain text with `backtick` spans only -- no other
+# markdown -- so the same string can be dropped into a Markdown bullet list
+# as-is, or passed through report.py's _md_inline_to_html() for HTML.
+# ---------------------------------------------------------------------------
+
+
+def _models_str(cost: Any) -> str:
+    """Distinct, sorted model names used across a run's steps (or '—')."""
+    models = sorted({s.model for s in cost.steps.values() if s.model})
+    return ", ".join(models) if models else "—"
+
+
+def _format_header(label_a: str, cost_a: Any, label_b: str, cost_b: Any) -> str:
+    return f"Comparing `{label_a}` ({_models_str(cost_a)}) vs. `{label_b}` ({_models_str(cost_b)})"
+
+
+def _format_enum_shift(fc: FieldChurn, limit: int = 5) -> str:
+    """'<value>' <pctA>% → <pctB>%' for the values with the largest shift, biggest first."""
+    freq_a, freq_b = fc.freq_a or {}, fc.freq_b or {}
+    keys = sorted(set(freq_a) | set(freq_b))
+    if not keys:
+        return ""
+    ranked = sorted(keys, key=lambda k: abs(freq_b.get(k, 0.0) - freq_a.get(k, 0.0)), reverse=True)
+    shown = ranked[:limit]
+    parts = [
+        f"{k!r} {freq_a.get(k, 0.0) * 100:.0f}% → {freq_b.get(k, 0.0) * 100:.0f}%" for k in shown
+    ]
+    if len(ranked) > limit:
+        parts.append("…")
+    return ", ".join(parts)
+
+
+def _format_field_churn_line(fc: FieldChurn) -> str:
+    """One line per field for the 'Per-field churn' section, no leading bullet marker."""
+    head = f"`{fc.field}`: {fc.changed} changed ({fc.changed_pct:.1f}%)"
+    if fc.kind == "enum":
+        shift = _format_enum_shift(fc)
+        return f"{head} — distribution shifted: {shift}" if shift else head
+    if fc.kind == "numeric":
+        if fc.mean_delta is None:
+            return head
+        sign = "+" if fc.mean_delta >= 0 else ""
+        return f"{head} — mean delta {sign}{fc.mean_delta:.2f}"
+    # text (String, or differs-only for Boolean/Date/JSON/List[String])
+    head = f"`{fc.field}`: {fc.changed} changed (text)"
+    if fc.len_delta_tokens is None:
+        return head
+    sign = "+" if fc.len_delta_tokens >= 0 else ""
+    return f"{head} — avg length {sign}{fc.len_delta_tokens:.0f} tokens"
+
+
+def _format_cost_delta_lines(cd: CostDelta, label_b: str) -> list[str]:
+    """Lines for the 'Cost delta' section: token deltas, cache hit rate, wall time."""
+
+    def _pct(delta: int, base: int) -> str:
+        if base == 0:
+            return "n/a" if delta == 0 else "new"
+        sign = "+" if delta >= 0 else ""
+        return f"{sign}{delta / base * 100:.0f}%"
+
+    return [
+        f"`{label_b}` used {_pct(cd.prompt_tokens_delta, cd.prompt_tokens_a)} input tokens, "
+        f"{_pct(cd.completion_tokens_delta, cd.completion_tokens_a)} output tokens "
+        f"({_format_tokens(cd.total_tokens_a)} → {_format_tokens(cd.total_tokens_b)} total).",
+        f"Cache hit rate: {cd.cache_hit_rate_a * 100:.0f}% → {cd.cache_hit_rate_b * 100:.0f}%.",
+        f"Wall time: {_format_seconds(cd.elapsed_seconds_a)} → "
+        f"{_format_seconds(cd.elapsed_seconds_b)}.",
+    ]
+
+
+# ---------------------------------------------------------------------------
 # compare() + ComparisonResult
 # ---------------------------------------------------------------------------
 
@@ -449,6 +522,46 @@ class ComparisonResult:
             elapsed_seconds_b=elapsed_b,
             elapsed_seconds_delta=elapsed_b - elapsed_a,
         )
+
+    def summary(self) -> str:
+        """Markdown summary — headline numbers, per-field churn, cost delta.
+
+        Mirrors the shape of ``PipelineResult.report()``: pasteable into
+        Slack/GitHub. Identical runs short-circuit to a one-line "no
+        differences" message instead of an empty churn/cost section.
+        """
+        total = len(self.aligned_a)
+        changed_n = len(self.changed_rows())
+        identical_n = total - changed_n
+
+        lines: list[str] = [
+            "# Pipeline Comparison Report",
+            "",
+            _format_header(self.label_a, self.result_a.cost, self.label_b, self.result_b.cost),
+            "",
+            f"**{total:,} rows compared**",
+            f"- {changed_n:,} rows changed in at least one field",
+            f"- {identical_n:,} rows identical",
+            "",
+        ]
+
+        if changed_n == 0:
+            lines.append("No differences detected between the two runs.")
+            return "\n".join(lines).rstrip() + "\n"
+
+        if self.fields:
+            lines.append("**Per-field churn:**")
+            shifts = self.distribution_shift()
+            for f in self.fields:
+                lines.append(f"- {_format_field_churn_line(shifts[f])}")
+            lines.append("")
+
+        lines.append("**Cost delta:**")
+        for line in _format_cost_delta_lines(self.cost_delta(), self.label_b):
+            lines.append(f"- {line}")
+        lines.append("")
+
+        return "\n".join(lines).rstrip() + "\n"
 
 
 def compare(

--- a/accrue/pipeline/compare.py
+++ b/accrue/pipeline/compare.py
@@ -214,6 +214,32 @@ class FieldChurn:
         return (self.changed / self.total * 100) if self.total else 0.0
 
 
+@dataclass
+class CostDelta:
+    """Token/cache/latency delta between two pipeline runs.
+
+    No pricing fields by design -- there is no pricing data anywhere in
+    Accrue, so "cost" here means tokens, cache efficiency, and wall time
+    only.
+    """
+
+    prompt_tokens_a: int
+    prompt_tokens_b: int
+    prompt_tokens_delta: int
+    completion_tokens_a: int
+    completion_tokens_b: int
+    completion_tokens_delta: int
+    total_tokens_a: int
+    total_tokens_b: int
+    total_tokens_delta: int
+    cache_hit_rate_a: float
+    cache_hit_rate_b: float
+    cache_hit_rate_delta: float
+    elapsed_seconds_a: float
+    elapsed_seconds_b: float
+    elapsed_seconds_delta: float
+
+
 # ---------------------------------------------------------------------------
 # compare() + ComparisonResult
 # ---------------------------------------------------------------------------
@@ -380,6 +406,49 @@ class ComparisonResult:
                     len_delta_tokens=len_delta,
                 )
         return result
+
+    def cost_delta(self) -> CostDelta:
+        """Token, cache-hit-rate, and wall-time delta between the two runs.
+
+        ``StepUsage.cache_hit_rate`` is a per-step property only -- there
+        is no top-level aggregate on ``CostSummary``, so the overall rate
+        for each side is computed here as
+        ``sum(cache_hits) / sum(cache_hits + cache_misses)`` across that
+        side's ``cost.steps`` (0.0 if neither ever ran, instead of
+        dividing by zero).
+
+        No ``$``/pricing fields -- see :class:`CostDelta`.
+        """
+        cost_a, cost_b = self.result_a.cost, self.result_b.cost
+
+        def _cache_rate(cost: Any) -> float:
+            hits = sum(s.cache_hits for s in cost.steps.values())
+            total = sum(s.cache_hits + s.cache_misses for s in cost.steps.values())
+            return hits / total if total > 0 else 0.0
+
+        rate_a, rate_b = _cache_rate(cost_a), _cache_rate(cost_b)
+        elapsed_a = self.result_a.pipeline_elapsed_seconds
+        elapsed_b = self.result_b.pipeline_elapsed_seconds
+
+        return CostDelta(
+            prompt_tokens_a=cost_a.total_prompt_tokens,
+            prompt_tokens_b=cost_b.total_prompt_tokens,
+            prompt_tokens_delta=cost_b.total_prompt_tokens - cost_a.total_prompt_tokens,
+            completion_tokens_a=cost_a.total_completion_tokens,
+            completion_tokens_b=cost_b.total_completion_tokens,
+            completion_tokens_delta=(
+                cost_b.total_completion_tokens - cost_a.total_completion_tokens
+            ),
+            total_tokens_a=cost_a.total_tokens,
+            total_tokens_b=cost_b.total_tokens,
+            total_tokens_delta=cost_b.total_tokens - cost_a.total_tokens,
+            cache_hit_rate_a=rate_a,
+            cache_hit_rate_b=rate_b,
+            cache_hit_rate_delta=rate_b - rate_a,
+            elapsed_seconds_a=elapsed_a,
+            elapsed_seconds_b=elapsed_b,
+            elapsed_seconds_delta=elapsed_b - elapsed_a,
+        )
 
 
 def compare(

--- a/accrue/pipeline/compare.py
+++ b/accrue/pipeline/compare.py
@@ -1,0 +1,283 @@
+"""``accrue.compare()`` — diff two ``PipelineResult`` objects.
+
+The Accrue user's actual iteration loop is "tweak a prompt, re-run, did
+anything meaningful change?" — not "what's the F1 score against ground
+truth." They have no labels, just two runs. ``compare()`` answers that
+question directly: align the two result sets, classify each output field
+by its spec (enum / numeric / text), and report what moved.
+
+This module reuses the rendering primitives from :mod:`.report` (token/
+seconds formatting, the HTML stylesheet, inline-markdown escaping, and the
+null-safe check) so a comparison report looks and feels like
+``result.report()``.
+"""
+
+from __future__ import annotations
+
+import json
+import warnings
+from dataclasses import dataclass
+from typing import Any
+
+import pandas as pd
+
+from .pipeline import PipelineResult
+from .report import _is_null
+
+__all__ = ["compare", "ComparisonResult"]
+
+
+# ---------------------------------------------------------------------------
+# Row alignment
+# ---------------------------------------------------------------------------
+
+
+def _is_default_range_index(idx: pd.Index) -> bool:
+    """True if *idx* is the plain positional ``RangeIndex(0, len(idx))``.
+
+    This is how both the ``list[dict]`` input path and a freshly-built
+    DataFrame index look — i.e. "no caller-supplied index". A caller who
+    sliced/reindexed a DataFrame (even into another RangeIndex with a
+    different start/step) gets treated as a "real" index instead.
+    """
+    return isinstance(idx, pd.RangeIndex) and idx.equals(pd.RangeIndex(len(idx)))
+
+
+def _align_rows(df_a: pd.DataFrame, df_b: pd.DataFrame) -> tuple[list[int], list[int], str]:
+    """Pair up rows of *df_a* and *df_b* for comparison.
+
+    Returns ``(positions_a, positions_b, mode)`` where ``positions_a[i]``
+    (an integer position, suitable for ``.iloc``) pairs with
+    ``positions_b[i]``, and ``mode`` is ``"positional"`` or ``"label"``.
+
+    A blind ``df_a.index & df_b.index`` is not safe here: it silently
+    produces an empty (or wrong) result when the indexes are different
+    dtypes, or double-counts/misaligns when either index has duplicate
+    labels. So alignment is by explicit case:
+
+    - Both frames have the default positional RangeIndex (the common case
+      for ``list[dict]`` input, or any freshly-built DataFrame) -> align by
+      position, on the shorter length.
+    - Both frames carry a real (non-default) index -> align by label, but
+      only after confirming each index is unique.
+    - Anything else (one default + one real, or a non-unique real index on
+      either side) -> warn and fall back to positional alignment.
+    """
+    default_a = _is_default_range_index(df_a.index)
+    default_b = _is_default_range_index(df_b.index)
+
+    if default_a and default_b:
+        n = min(len(df_a), len(df_b))
+        if len(df_a) != len(df_b):
+            warnings.warn(
+                f"compare(): row counts differ (A={len(df_a)}, B={len(df_b)}); "
+                f"comparing the first {n} row(s) positionally and ignoring the rest.",
+                stacklevel=3,
+            )
+        return list(range(n)), list(range(n)), "positional"
+
+    if not default_a and not default_b:
+        if df_a.index.is_unique and df_b.index.is_unique:
+            labels_b = set(df_b.index)
+            common = [lab for lab in df_a.index if lab in labels_b]
+            unmatched_a = len(df_a) - len(common)
+            unmatched_b = len(df_b) - len(common)
+            if unmatched_a or unmatched_b:
+                warnings.warn(
+                    f"compare(): {unmatched_a} row(s) in A and {unmatched_b} row(s) in B "
+                    "have no matching index label on the other side; comparing the "
+                    "intersection only.",
+                    stacklevel=3,
+                )
+            pos_a = [df_a.index.get_loc(lab) for lab in common]
+            pos_b = [df_b.index.get_loc(lab) for lab in common]
+            return pos_a, pos_b, "label"
+
+        warnings.warn(
+            "compare(): index is non-unique on one or both sides; "
+            "falling back to positional row alignment.",
+            stacklevel=3,
+        )
+        n = min(len(df_a), len(df_b))
+        return list(range(n)), list(range(n)), "positional"
+
+    # Mixed: one default RangeIndex, one real index.
+    warnings.warn(
+        "compare(): one side has a default positional index and the other a custom "
+        "index; falling back to positional row alignment.",
+        stacklevel=3,
+    )
+    n = min(len(df_a), len(df_b))
+    return list(range(n)), list(range(n)), "positional"
+
+
+# ---------------------------------------------------------------------------
+# Cell equality
+# ---------------------------------------------------------------------------
+
+
+def _stable_repr(v: Any) -> str:
+    """Deterministic string form for values that can't be compared/hashed directly."""
+    try:
+        return json.dumps(v, sort_keys=True, default=str)
+    except TypeError:
+        return repr(v)
+
+
+def _cells_equal(x: Any, y: Any) -> bool:
+    """True if *x* and *y* should be treated as the same output value.
+
+    A naive ``x != y`` has two problems here: ``NaN != NaN`` is ``True``
+    (so two byte-identical runs with missing values would be reported as
+    fully changed), and it can raise outright on container cells (JSON /
+    ``List[String]`` fields hold ``dict``/``list`` values, and an
+    elementwise numpy comparison of two such cells can come back as an
+    array, which blows up on ``bool()``).
+
+    Both-null compares equal (reusing :func:`_is_null`, the same null
+    check ``report()`` uses). Otherwise try direct equality; if that
+    raises or doesn't resolve to a plain boolean, fall back to a
+    sort-keyed JSON (or ``repr``, if not JSON-able) comparison.
+    """
+    x_null, y_null = _is_null(x), _is_null(y)
+    if x_null or y_null:
+        return x_null and y_null
+    try:
+        return bool(x == y)
+    except (ValueError, TypeError):
+        return _stable_repr(x) == _stable_repr(y)
+
+
+def _value_counts_safe(series: pd.Series) -> pd.Series:
+    """``value_counts()`` that tolerates unhashable cells (lists/dicts).
+
+    Container cells (JSON / ``List[String]`` fields) raise
+    ``TypeError: unhashable type`` from the normal hash-based counting
+    path, so non-scalar cells are stringified first via :func:`_stable_repr`.
+    """
+    stringified = [
+        v if isinstance(v, (str, int, float, bool)) else _stable_repr(v)
+        for v in series.tolist()
+        if not _is_null(v)
+    ]
+    return pd.Series(stringified, dtype=object).value_counts()
+
+
+# ---------------------------------------------------------------------------
+# compare() + ComparisonResult
+# ---------------------------------------------------------------------------
+
+
+def _to_dataframe(data: pd.DataFrame | list[dict[str, Any]]) -> pd.DataFrame:
+    if isinstance(data, pd.DataFrame):
+        return data
+    return pd.DataFrame(data)
+
+
+@dataclass
+class ComparisonResult:
+    """Diff between two :class:`~accrue.pipeline.pipeline.PipelineResult` runs.
+
+    Built by :func:`compare`; not meant to be constructed directly.
+
+    Attributes:
+        result_a: The first (``label_a``) pipeline result.
+        result_b: The second (``label_b``) pipeline result.
+        label_a: Display label for ``result_a`` (default ``"A"``).
+        label_b: Display label for ``result_b`` (default ``"B"``).
+        fields: Output field names compared — present as a column in both
+            ``result_a.data`` and ``result_b.data``, and declared in the
+            field specs of at least one side.
+        field_specs: Field-spec dict per compared field, used to classify
+            it as enum / numeric / text. Prefers ``result_a``'s spec,
+            falling back to ``result_b``'s.
+        aligned_a: ``result_a``'s data, sliced to the aligned row set and
+            reset to a plain ``0..n-1`` index. Row ``i`` pairs with
+            ``aligned_b`` row ``i``.
+        aligned_b: ``result_b``'s data, aligned the same way.
+        align_mode: ``"positional"`` or ``"label"`` — how rows were paired
+            (see :func:`_align_rows`).
+        pos_a: Original integer position in ``result_a.data`` for each
+            aligned row (lines up with ``RowError.row_index``).
+        pos_b: Original integer position in ``result_b.data`` for each
+            aligned row.
+    """
+
+    result_a: PipelineResult
+    result_b: PipelineResult
+    label_a: str
+    label_b: str
+    fields: list[str]
+    field_specs: dict[str, dict[str, Any]]
+    aligned_a: pd.DataFrame
+    aligned_b: pd.DataFrame
+    align_mode: str
+    pos_a: list[int]
+    pos_b: list[int]
+
+
+def compare(
+    a: PipelineResult,
+    b: PipelineResult,
+    *,
+    label_a: str = "A",
+    label_b: str = "B",
+) -> ComparisonResult:
+    """Diff two pipeline runs — the prompt-iteration loop in one call.
+
+    ``result_a``/``result_b`` need not come from the same pipeline
+    definition; only the overlap of their output fields is compared.
+
+    Args:
+        a: The "before" run.
+        b: The "after" run.
+        label_a: Display label for *a* in summaries/reports.
+        label_b: Display label for *b* in summaries/reports.
+
+    Returns:
+        A :class:`ComparisonResult`. Call ``.summary()`` for a Markdown
+        readout, ``.changed_rows()`` for the rows that differ, or
+        ``.report()`` to render/save the full comparison.
+    """
+    df_a = _to_dataframe(a.data)
+    df_b = _to_dataframe(b.data)
+
+    pos_a, pos_b, align_mode = _align_rows(df_a, df_b)
+    aligned_a = df_a.iloc[pos_a].reset_index(drop=True)
+    aligned_b = df_b.iloc[pos_b].reset_index(drop=True)
+
+    spec_keys_a = set(a.field_specs)
+    spec_keys_b = set(b.field_specs)
+    if spec_keys_a != spec_keys_b:
+        only_a = sorted(spec_keys_a - spec_keys_b)
+        only_b = sorted(spec_keys_b - spec_keys_a)
+        warnings.warn(
+            f"compare(): field-spec schemas differ between {label_a!r} and {label_b!r} "
+            f"(only in {label_a}: {only_a or 'none'}; only in {label_b}: {only_b or 'none'}); "
+            "comparing the overlapping output fields only.",
+            stacklevel=2,
+        )
+
+    candidate_fields = spec_keys_a | spec_keys_b
+    fields = sorted(
+        f
+        for f in candidate_fields
+        if not f.startswith("__") and f in aligned_a.columns and f in aligned_b.columns
+    )
+    field_specs = {
+        f: (a.field_specs[f] if f in a.field_specs else b.field_specs.get(f, {})) for f in fields
+    }
+
+    return ComparisonResult(
+        result_a=a,
+        result_b=b,
+        label_a=label_a,
+        label_b=label_b,
+        fields=fields,
+        field_specs=field_specs,
+        aligned_a=aligned_a,
+        aligned_b=aligned_b,
+        align_mode=align_mode,
+        pos_a=pos_a,
+        pos_b=pos_b,
+    )

--- a/accrue/pipeline/compare.py
+++ b/accrue/pipeline/compare.py
@@ -17,12 +17,13 @@ from __future__ import annotations
 import json
 import warnings
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import pandas as pd
 
 from .pipeline import PipelineResult
-from .report import _format_seconds, _format_tokens, _is_null
+from .report import _HTML_STYLE, _format_seconds, _format_tokens, _is_null, _md_inline_to_html
 
 __all__ = ["compare", "ComparisonResult"]
 
@@ -562,6 +563,80 @@ class ComparisonResult:
         lines.append("")
 
         return "\n".join(lines).rstrip() + "\n"
+
+    def report(self, output_format: str = "markdown", path: str | None = None) -> str:
+        """Render the comparison — Markdown (mirrors :meth:`summary`) or self-contained HTML.
+
+        Mirrors :meth:`PipelineResult.report`'s signature.
+
+        Args:
+            output_format: ``"markdown"`` (default) or ``"html"``.
+            path: If given, also write the rendered report to this path
+                (UTF-8).
+
+        Returns:
+            The rendered report as a string.
+
+        Raises:
+            ValueError: If ``output_format`` isn't ``"markdown"`` or ``"html"``.
+        """
+        fmt = output_format.lower()
+        if fmt == "markdown":
+            text = self.summary()
+        elif fmt == "html":
+            text = self._render_html()
+        else:
+            raise ValueError(
+                f"Unknown report format {output_format!r}; expected 'markdown' or 'html'."
+            )
+
+        if path is not None:
+            Path(path).write_text(text, encoding="utf-8")
+        return text
+
+    def _render_html(self) -> str:
+        """Self-contained HTML rendering of the same content as :meth:`summary`."""
+        total = len(self.aligned_a)
+        changed_n = len(self.changed_rows())
+        identical_n = total - changed_n
+
+        header = _format_header(self.label_a, self.result_a.cost, self.label_b, self.result_b.cost)
+        parts: list[str] = [
+            "<!doctype html>",
+            '<html lang="en"><head>',
+            '<meta charset="utf-8">',
+            "<title>Pipeline Comparison Report</title>",
+            f"<style>{_HTML_STYLE}</style>",
+            "</head><body>",
+            "<h1>Pipeline Comparison Report</h1>",
+            f'<p class="headline">{_md_inline_to_html(header)}</p>',
+            f"<p><strong>{total:,} rows compared</strong> &middot; "
+            f"{changed_n:,} changed &middot; {identical_n:,} identical</p>",
+        ]
+
+        if changed_n == 0:
+            parts.append("<h2>No differences detected</h2>")
+            parts.append("<p>The two runs produced identical output on every compared field.</p>")
+            parts.append("</body></html>")
+            return "\n".join(parts) + "\n"
+
+        if self.fields:
+            parts.append("<h2>Per-field churn</h2>")
+            parts.append('<ul class="findings">')
+            shifts = self.distribution_shift()
+            for f in self.fields:
+                line = _md_inline_to_html(_format_field_churn_line(shifts[f]))
+                parts.append(f"<li>{line}</li>")
+            parts.append("</ul>")
+
+        parts.append("<h2>Cost delta</h2>")
+        parts.append('<ul class="findings">')
+        for line in _format_cost_delta_lines(self.cost_delta(), self.label_b):
+            parts.append(f"<li>{_md_inline_to_html(line)}</li>")
+        parts.append("</ul>")
+
+        parts.append("</body></html>")
+        return "\n".join(parts) + "\n"
 
 
 def compare(

--- a/docs/guides/compare.md
+++ b/docs/guides/compare.md
@@ -1,0 +1,85 @@
+# Comparing two runs — `accrue.compare()`
+
+The way you actually iterate on a pipeline is: run it, eyeball the output,
+tweak a prompt, run it again, and ask *"did v2 change anything meaningful,
+and are the changed rows better?"* You have no labels — just two runs and a
+hunch. `accrue.compare()` makes that one line.
+
+```python
+import accrue
+
+result_a = pipeline.run(df)   # v1
+# ... tweak a prompt ...
+result_b = pipeline.run(df)   # v2
+
+diff = accrue.compare(result_a, result_b, label_a="v1", label_b="v2")
+
+print(diff.summary())                       # Markdown for terminal/Slack
+diff.report(output_format="html", path="v1-vs-v2.html")  # self-contained HTML
+```
+
+The two results don't have to come from the same pipeline definition — only
+the overlap of their output fields is compared. If the field-spec schemas
+differ, `compare()` warns (it never raises) and compares the overlap only.
+
+## What you get back
+
+`compare()` returns a `ComparisonResult` with four methods:
+
+| Method | Returns |
+|---|---|
+| `changed_rows(field=None)` | A before/after DataFrame of rows that differ — on any field, or on one named field. |
+| `distribution_shift()` | Per-field churn keyed by field name: enum frequency tables, numeric mean/std deltas, text differs-counts. |
+| `cost_delta()` | Token, cache-hit-rate, and wall-time deltas between the two runs. |
+| `summary()` / `report()` | A rendered Markdown (or HTML) report combining all of the above. |
+
+```python
+diff.changed_rows()             # every row where any output field moved
+diff.changed_rows("category")   # only rows where `category` changed
+diff.distribution_shift()       # {"category": FieldChurn(...), "score": ...}
+diff.cost_delta()               # CostDelta(total_tokens_delta=..., ...)
+```
+
+## How rows are paired
+
+- If both runs' data carry the **default positional index** (the common
+  case — `list[dict]` input, or a freshly-built DataFrame), rows are
+  aligned by position. Differing row counts compare the shorter prefix and
+  warn about the rest.
+- If both carry a **real, unique index**, rows are aligned by label, on the
+  intersection. Labels present on only one side are warned about and
+  skipped.
+- A non-unique index, or one default and one custom index, falls back to
+  positional alignment with a warning — never a silent misalignment.
+
+## How fields are classified
+
+Each compared field is classified from its spec, exactly as
+`result.report()` does:
+
+- **Enum** (`enum` set) — before/after frequency table, surfaced in the
+  summary as `'AI' 22% → 31%`.
+- **Number** (`type: "Number"`) — mean and std, plus the mean delta.
+  Non-numeric values coerce to `NaN` rather than erroring.
+- **Everything else** (String / Boolean / Date / JSON / `List[String]`) —
+  a "differs" count only. String fields additionally get an approximate
+  token-length delta (`len(str) // 4`). Free-text fields are intentionally
+  **not** fuzzy-matched or scored for semantic similarity — that's out of
+  scope.
+
+## Edge cases, handled
+
+- **Different row counts** → compare the intersection, warn about the rest.
+- **One run errored on a row, the other didn't** → flagged as a change (not
+  a value diff), cross-referenced by each side's `result.errors`.
+- **Identical runs** → `summary()` short-circuits to a one-line "no
+  differences" message. Still useful as confirmation.
+
+## What's deliberately not here
+
+- **No `$`/pricing.** There's no pricing data anywhere in Accrue, so
+  `cost_delta()` reports tokens, cache efficiency, and wall time — never a
+  dollar figure it would have to invent.
+- **No statistical significance testing** (chi-square, etc.). Distribution
+  shift numbers are the right level of detail for eyeballing a prompt change.
+- **No N-way comparison.** `compare()` is pairwise; compare runs two at a time.

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -288,3 +288,104 @@ class TestChangedRows:
         diff = compare(a, b)
         out = diff.changed_rows()
         assert out.empty
+
+
+# -- distribution_shift() --------------------------------------------------------
+
+
+class TestDistributionShift:
+    def test_enum_field_frequency_table(self):
+        df_a = pd.DataFrame({"category": ["AI", "AI", "Other", "Other", "Other"]})
+        df_b = pd.DataFrame({"category": ["AI", "AI", "AI", "Other", "Other"]})
+        a = _result(df_a, {"category": {"enum": ["AI", "Other"]}})
+        b = _result(df_b, {"category": {"enum": ["AI", "Other"]}})
+        diff = compare(a, b)
+        shift = diff.distribution_shift()["category"]
+
+        assert shift.kind == "enum"
+        assert shift.changed == 1
+        assert shift.freq_a == {"AI": 0.4, "Other": 0.6}
+        assert shift.freq_b == {"AI": 0.6, "Other": 0.4}
+
+    def test_enum_field_with_container_values_does_not_raise(self):
+        # Defensive: enum classification keys off the spec, not the dtype,
+        # but value_counts() must still tolerate non-scalar cells.
+        df_a = pd.DataFrame({"tags": [["a"], ["a"], ["b"]]})
+        df_b = pd.DataFrame({"tags": [["a"], ["b"], ["b"]]})
+        a = _result(df_a, {"tags": {"enum": ["a", "b"]}})
+        b = _result(df_b, {"tags": {"enum": ["a", "b"]}})
+        diff = compare(a, b)
+        shift = diff.distribution_shift()["tags"]
+        assert shift.kind == "enum"
+        assert sum(shift.freq_a.values()) == pytest.approx(1.0)
+
+    def test_numeric_field_mean_delta(self):
+        df_a = pd.DataFrame({"score": [10, 20, 30]})
+        df_b = pd.DataFrame({"score": [10, 25, 40]})
+        a = _result(df_a, {"score": {"type": "Number"}})
+        b = _result(df_b, {"score": {"type": "Number"}})
+        diff = compare(a, b)
+        shift = diff.distribution_shift()["score"]
+
+        assert shift.kind == "numeric"
+        assert shift.changed == 2
+        assert shift.mean_a == pytest.approx(20.0)
+        assert shift.mean_b == pytest.approx(25.0)
+        assert shift.mean_delta == pytest.approx(5.0)
+        assert shift.std_a is not None and shift.std_b is not None
+
+    def test_numeric_field_non_numeric_values_coerced_to_nan(self):
+        df_a = pd.DataFrame({"score": ["10", "oops", "30"]})
+        df_b = pd.DataFrame({"score": ["10", "20", "30"]})
+        a = _result(df_a, {"score": {"type": "Number"}})
+        b = _result(df_b, {"score": {"type": "Number"}})
+        diff = compare(a, b)
+        shift = diff.distribution_shift()["score"]
+        assert shift.mean_a == pytest.approx(20.0)  # (10 + 30) / 2, "oops" dropped
+        assert shift.mean_b == pytest.approx(20.0)
+
+    def test_numeric_field_all_non_numeric_yields_none_mean(self):
+        df = pd.DataFrame({"score": ["nope", "also-nope"]})
+        a = _result(df, {"score": {"type": "Number"}})
+        b = _result(df.copy(), {"score": {"type": "Number"}})
+        diff = compare(a, b)
+        shift = diff.distribution_shift()["score"]
+        assert shift.mean_a is None
+        assert shift.mean_delta is None
+
+    def test_string_field_differs_count_and_token_length_delta(self):
+        df_a = pd.DataFrame({"summary": ["short text", "another one here"]})
+        df_b = pd.DataFrame({"summary": ["short text", "a much longer summary here now"]})
+        a = _result(df_a, {"summary": {"type": "String"}})
+        b = _result(df_b, {"summary": {"type": "String"}})
+        diff = compare(a, b)
+        shift = diff.distribution_shift()["summary"]
+
+        assert shift.kind == "text"
+        assert shift.changed == 1
+        assert shift.avg_len_tokens_a is not None
+        assert shift.avg_len_tokens_b is not None
+        assert shift.len_delta_tokens > 0
+
+    def test_boolean_field_differs_count_only_no_length_delta(self):
+        df_a = pd.DataFrame({"flag": [True, False]})
+        df_b = pd.DataFrame({"flag": [True, True]})
+        a = _result(df_a, {"flag": {"type": "Boolean"}})
+        b = _result(df_b, {"flag": {"type": "Boolean"}})
+        diff = compare(a, b)
+        shift = diff.distribution_shift()["flag"]
+
+        assert shift.kind == "text"
+        assert shift.changed == 1
+        assert shift.avg_len_tokens_a is None
+        assert shift.len_delta_tokens is None
+
+    def test_json_field_differs_count_only_does_not_raise(self):
+        df_a = pd.DataFrame({"meta": [{"k": 1}, {"k": 2}]})
+        df_b = pd.DataFrame({"meta": [{"k": 1}, {"k": 9}]})
+        a = _result(df_a, {"meta": {"type": "JSON"}})
+        b = _result(df_b, {"meta": {"type": "JSON"}})
+        diff = compare(a, b)
+        shift = diff.distribution_shift()["meta"]
+        assert shift.kind == "text"
+        assert shift.changed == 1

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import warnings
 
 import pandas as pd
@@ -15,12 +16,25 @@ from accrue.pipeline.compare import (
     compare,
 )
 from accrue.pipeline.pipeline import PipelineResult
+from accrue.schemas.base import CostSummary, StepUsage
 
 # -- helpers ------------------------------------------------------------------
 
 
-def _result(data, field_specs=None, errors=None) -> PipelineResult:
-    return PipelineResult(data=data, field_specs=field_specs or {}, errors=errors or [])
+def _result(
+    data,
+    field_specs=None,
+    errors=None,
+    cost=None,
+    pipeline_elapsed_seconds=0.0,
+) -> PipelineResult:
+    return PipelineResult(
+        data=data,
+        field_specs=field_specs or {},
+        errors=errors or [],
+        cost=cost or CostSummary(),
+        pipeline_elapsed_seconds=pipeline_elapsed_seconds,
+    )
 
 
 # -- _align_rows ---------------------------------------------------------------
@@ -389,3 +403,78 @@ class TestDistributionShift:
         shift = diff.distribution_shift()["meta"]
         assert shift.kind == "text"
         assert shift.changed == 1
+
+
+# -- cost_delta() -----------------------------------------------------------------
+
+
+class TestCostDelta:
+    def test_token_deltas(self):
+        df = pd.DataFrame({"x": [1]})
+        cost_a = CostSummary(
+            total_prompt_tokens=100,
+            total_completion_tokens=50,
+            total_tokens=150,
+            steps={"s": StepUsage(prompt_tokens=100, completion_tokens=50, total_tokens=150)},
+        )
+        cost_b = CostSummary(
+            total_prompt_tokens=112,
+            total_completion_tokens=59,
+            total_tokens=171,
+            steps={"s": StepUsage(prompt_tokens=112, completion_tokens=59, total_tokens=171)},
+        )
+        a = _result(df, {"x": {}}, cost=cost_a)
+        b = _result(df.copy(), {"x": {}}, cost=cost_b)
+        diff = compare(a, b)
+        delta = diff.cost_delta()
+
+        assert delta.prompt_tokens_delta == 12
+        assert delta.completion_tokens_delta == 9
+        assert delta.total_tokens_delta == 21
+
+    def test_cache_hit_rate_is_aggregated_across_steps(self):
+        df = pd.DataFrame({"x": [1]})
+        cost_a = CostSummary(
+            steps={
+                "s1": StepUsage(cache_hits=90, cache_misses=10),
+                "s2": StepUsage(cache_hits=0, cache_misses=100),
+            }
+        )
+        cost_b = CostSummary(steps={"s1": StepUsage(cache_hits=0, cache_misses=100)})
+        a = _result(df, {"x": {}}, cost=cost_a)
+        b = _result(df.copy(), {"x": {}}, cost=cost_b)
+        diff = compare(a, b)
+        delta = diff.cost_delta()
+
+        # 90 hits / 200 total = 0.45 on A; 0 on B.
+        assert delta.cache_hit_rate_a == pytest.approx(0.45)
+        assert delta.cache_hit_rate_b == pytest.approx(0.0)
+        assert delta.cache_hit_rate_delta == pytest.approx(-0.45)
+
+    def test_cache_hit_rate_guards_divide_by_zero(self):
+        df = pd.DataFrame({"x": [1]})
+        a = _result(df, {"x": {}}, cost=CostSummary())
+        b = _result(df.copy(), {"x": {}}, cost=CostSummary())
+        diff = compare(a, b)
+        delta = diff.cost_delta()
+        assert delta.cache_hit_rate_a == 0.0
+        assert delta.cache_hit_rate_b == 0.0
+        assert delta.cache_hit_rate_delta == 0.0
+
+    def test_latency_delta(self):
+        df = pd.DataFrame({"x": [1]})
+        a = _result(df, {"x": {}}, pipeline_elapsed_seconds=10.0)
+        b = _result(df.copy(), {"x": {}}, pipeline_elapsed_seconds=14.5)
+        diff = compare(a, b)
+        delta = diff.cost_delta()
+        assert delta.elapsed_seconds_a == 10.0
+        assert delta.elapsed_seconds_b == 14.5
+        assert delta.elapsed_seconds_delta == pytest.approx(4.5)
+
+    def test_no_pricing_fields(self):
+        df = pd.DataFrame({"x": [1]})
+        a, b = _result(df, {"x": {}}), _result(df.copy(), {"x": {}})
+        diff = compare(a, b)
+        delta = diff.cost_delta()
+        field_names = {f.name for f in dataclasses.fields(delta)}
+        assert not any("dollar" in n or n.startswith("$") or "price" in n for n in field_names)

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,215 @@
+"""Tests for ``accrue.compare()`` — diffing two ``PipelineResult`` objects."""
+
+from __future__ import annotations
+
+import warnings
+
+import pandas as pd
+import pytest
+
+from accrue.pipeline.compare import (
+    ComparisonResult,
+    _align_rows,
+    _cells_equal,
+    compare,
+)
+from accrue.pipeline.pipeline import PipelineResult
+
+# -- helpers ------------------------------------------------------------------
+
+
+def _result(data, field_specs=None) -> PipelineResult:
+    return PipelineResult(data=data, field_specs=field_specs or {})
+
+
+# -- _align_rows ---------------------------------------------------------------
+
+
+class TestAlignRows:
+    def test_both_default_range_index_same_length(self):
+        df_a = pd.DataFrame({"x": [1, 2, 3]})
+        df_b = pd.DataFrame({"x": [4, 5, 6]})
+        pos_a, pos_b, mode = _align_rows(df_a, df_b)
+        assert mode == "positional"
+        assert pos_a == [0, 1, 2]
+        assert pos_b == [0, 1, 2]
+
+    def test_both_default_range_index_different_length_warns(self):
+        df_a = pd.DataFrame({"x": [1, 2, 3, 4]})
+        df_b = pd.DataFrame({"x": [4, 5]})
+        with pytest.warns(UserWarning, match="row counts differ"):
+            pos_a, pos_b, mode = _align_rows(df_a, df_b)
+        assert mode == "positional"
+        assert pos_a == [0, 1]
+        assert pos_b == [0, 1]
+
+    def test_both_real_unique_index_aligns_by_label(self):
+        df_a = pd.DataFrame({"x": [1, 2, 3]}, index=["r1", "r2", "r3"])
+        df_b = pd.DataFrame({"x": [9, 8, 7]}, index=["r3", "r1", "r2"])
+        pos_a, pos_b, mode = _align_rows(df_a, df_b)
+        assert mode == "label"
+        # Order follows df_a's index order: r1, r2, r3.
+        assert [df_a.index[i] for i in pos_a] == ["r1", "r2", "r3"]
+        assert [df_b.index[i] for i in pos_b] == ["r1", "r2", "r3"]
+
+    def test_real_index_partial_overlap_warns_and_compares_intersection(self):
+        df_a = pd.DataFrame({"x": [1, 2, 3]}, index=["r1", "r2", "r3"])
+        df_b = pd.DataFrame({"x": [9, 8]}, index=["r2", "r4"])
+        with pytest.warns(UserWarning, match="no matching index label"):
+            pos_a, pos_b, mode = _align_rows(df_a, df_b)
+        assert mode == "label"
+        assert [df_a.index[i] for i in pos_a] == ["r2"]
+        assert [df_b.index[i] for i in pos_b] == ["r2"]
+
+    def test_duplicate_labels_falls_back_to_positional(self):
+        df_a = pd.DataFrame({"x": [1, 2, 3]}, index=["r1", "r1", "r2"])
+        df_b = pd.DataFrame({"x": [9, 8, 7]}, index=["r1", "r2", "r3"])
+        with pytest.warns(UserWarning, match="non-unique"):
+            pos_a, pos_b, mode = _align_rows(df_a, df_b)
+        assert mode == "positional"
+        assert pos_a == [0, 1, 2]
+        assert pos_b == [0, 1, 2]
+
+    def test_mixed_default_and_real_index_falls_back_to_positional(self):
+        df_a = pd.DataFrame({"x": [1, 2, 3]})  # default RangeIndex
+        df_b = pd.DataFrame({"x": [9, 8, 7]}, index=["r1", "r2", "r3"])
+        with pytest.warns(UserWarning, match="custom index"):
+            pos_a, pos_b, mode = _align_rows(df_a, df_b)
+        assert mode == "positional"
+        assert pos_a == [0, 1, 2]
+        assert pos_b == [0, 1, 2]
+
+
+# -- _cells_equal ---------------------------------------------------------------
+
+
+class TestCellsEqual:
+    def test_both_nan_is_equal(self):
+        assert _cells_equal(float("nan"), float("nan")) is True
+
+    def test_none_and_nan_is_equal(self):
+        assert _cells_equal(None, float("nan")) is True
+
+    def test_null_vs_value_is_not_equal(self):
+        assert _cells_equal(None, "x") is False
+        assert _cells_equal("x", None) is False
+
+    def test_plain_scalars(self):
+        assert _cells_equal("a", "a") is True
+        assert _cells_equal("a", "b") is False
+        assert _cells_equal(1, 1) is True
+        assert _cells_equal(1, 2) is False
+
+    def test_list_cells_do_not_raise(self):
+        assert _cells_equal(["a", "b"], ["a", "b"]) is True
+        assert _cells_equal(["a", "b"], ["a", "c"]) is False
+
+    def test_dict_cells_do_not_raise(self):
+        assert _cells_equal({"a": 1}, {"a": 1}) is True
+        assert _cells_equal({"a": 1}, {"a": 2}) is False
+
+    def test_dict_key_order_does_not_matter(self):
+        assert _cells_equal({"a": 1, "b": 2}, {"b": 2, "a": 1}) is True
+
+
+# -- compare() / ComparisonResult -----------------------------------------------
+
+
+class TestCompare:
+    def test_returns_comparison_result_with_overlapping_fields(self):
+        df_a = pd.DataFrame({"category": ["A", "B"], "score": [1, 2]})
+        df_b = pd.DataFrame({"category": ["A", "C"], "score": [1, 3]})
+        a = _result(df_a, {"category": {"enum": ["A", "B", "C"]}, "score": {"type": "Number"}})
+        b = _result(df_b, {"category": {"enum": ["A", "B", "C"]}, "score": {"type": "Number"}})
+
+        diff = compare(a, b)
+        assert isinstance(diff, ComparisonResult)
+        assert diff.fields == ["category", "score"]
+        assert diff.label_a == "A"
+        assert diff.label_b == "B"
+        assert len(diff.aligned_a) == 2
+        assert len(diff.aligned_b) == 2
+
+    def test_custom_labels(self):
+        df = pd.DataFrame({"x": [1]})
+        a, b = _result(df, {"x": {}}), _result(df, {"x": {}})
+        diff = compare(a, b, label_a="v1", label_b="v2")
+        assert diff.label_a == "v1"
+        assert diff.label_b == "v2"
+
+    def test_schema_mismatch_warns_and_compares_overlap_only(self):
+        df_a = pd.DataFrame({"category": ["A"], "extra_a": [1]})
+        df_b = pd.DataFrame({"category": ["A"], "extra_b": [2]})
+        a = _result(df_a, {"category": {}, "extra_a": {}})
+        b = _result(df_b, {"category": {}, "extra_b": {}})
+
+        with pytest.warns(UserWarning, match="field-spec schemas differ"):
+            diff = compare(a, b)
+        # extra_a/extra_b aren't columns on both sides, so they're dropped
+        # even though the union-of-spec-keys check is what fired the warning.
+        assert diff.fields == ["category"]
+
+    def test_field_only_in_one_field_spec_but_column_in_both_is_included(self):
+        # b's pipeline didn't declare a spec for "tag" (e.g. it came from a
+        # FunctionStep with no FieldSpec), but the column is present on both
+        # sides, so it's still compared, using a's spec for classification.
+        df_a = pd.DataFrame({"tag": ["x"]})
+        df_b = pd.DataFrame({"tag": ["y"]})
+        a = _result(df_a, {"tag": {"type": "String"}})
+        b = _result(df_b, {})
+
+        diff = compare(a, b)
+        assert diff.fields == ["tag"]
+        assert diff.field_specs["tag"] == {"type": "String"}
+
+    def test_no_schema_mismatch_warning_when_specs_match(self):
+        df = pd.DataFrame({"x": [1]})
+        a, b = _result(df, {"x": {}}), _result(df, {"x": {}})
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            compare(a, b)
+
+    def test_identical_runs_with_null_cells_report_zero_changes(self):
+        df_a = pd.DataFrame({"score": [1.0, None, 3.0], "category": ["A", None, "C"]})
+        df_b = df_a.copy()
+        a = _result(df_a, {"score": {"type": "Number"}, "category": {"enum": ["A", "C"]}})
+        b = _result(df_b, {"score": {"type": "Number"}, "category": {"enum": ["A", "C"]}})
+
+        diff = compare(a, b)
+        for f in diff.fields:
+            col_a = diff.aligned_a[f].tolist()
+            col_b = diff.aligned_b[f].tolist()
+            assert all(_cells_equal(x, y) for x, y in zip(col_a, col_b))
+
+    def test_json_and_list_field_cells_do_not_raise(self):
+        df_a = pd.DataFrame(
+            {
+                "tags": [["a", "b"], ["c"]],
+                "meta": [{"k": 1}, {"k": 2}],
+            }
+        )
+        df_b = pd.DataFrame(
+            {
+                "tags": [["a", "b"], ["d"]],
+                "meta": [{"k": 1}, {"k": 3}],
+            }
+        )
+        a = _result(df_a, {"tags": {"type": "List[String]"}, "meta": {"type": "JSON"}})
+        b = _result(df_b, {"tags": {"type": "List[String]"}, "meta": {"type": "JSON"}})
+
+        diff = compare(a, b)
+        # Must not raise comparing these columns cell-by-cell.
+        for f in diff.fields:
+            col_a = diff.aligned_a[f].tolist()
+            col_b = diff.aligned_b[f].tolist()
+            results = [_cells_equal(x, y) for x, y in zip(col_a, col_b)]
+        assert results == [True, False]
+
+    def test_list_input_normalised_to_dataframe(self):
+        rows_a = [{"x": 1}, {"x": 2}]
+        rows_b = [{"x": 1}, {"x": 3}]
+        a = _result(rows_a, {"x": {"type": "Number"}})
+        b = _result(rows_b, {"x": {"type": "Number"}})
+        diff = compare(a, b)
+        assert isinstance(diff.aligned_a, pd.DataFrame)
+        assert diff.aligned_a["x"].tolist() == [1, 2]

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -7,6 +7,7 @@ import warnings
 import pandas as pd
 import pytest
 
+from accrue.core.exceptions import RowError
 from accrue.pipeline.compare import (
     ComparisonResult,
     _align_rows,
@@ -18,8 +19,8 @@ from accrue.pipeline.pipeline import PipelineResult
 # -- helpers ------------------------------------------------------------------
 
 
-def _result(data, field_specs=None) -> PipelineResult:
-    return PipelineResult(data=data, field_specs=field_specs or {})
+def _result(data, field_specs=None, errors=None) -> PipelineResult:
+    return PipelineResult(data=data, field_specs=field_specs or {}, errors=errors or [])
 
 
 # -- _align_rows ---------------------------------------------------------------
@@ -213,3 +214,77 @@ class TestCompare:
         diff = compare(a, b)
         assert isinstance(diff.aligned_a, pd.DataFrame)
         assert diff.aligned_a["x"].tolist() == [1, 2]
+
+
+# -- changed_rows() -------------------------------------------------------------
+
+
+class TestChangedRows:
+    def test_no_changes_returns_empty_dataframe(self):
+        df = pd.DataFrame({"category": ["A", "B"], "score": [1, 2]})
+        a = _result(df, {"category": {}, "score": {"type": "Number"}})
+        b = _result(df.copy(), {"category": {}, "score": {"type": "Number"}})
+        diff = compare(a, b)
+        out = diff.changed_rows()
+        assert out.empty
+        assert list(out.columns) == ["category_A", "category_B", "score_A", "score_B"]
+
+    def test_flags_rows_with_any_field_difference(self):
+        df_a = pd.DataFrame({"category": ["A", "B", "C"], "score": [1, 2, 3]})
+        df_b = pd.DataFrame({"category": ["A", "X", "C"], "score": [1, 2, 9]})
+        a = _result(df_a, {"category": {}, "score": {"type": "Number"}})
+        b = _result(df_b, {"category": {}, "score": {"type": "Number"}})
+        diff = compare(a, b)
+        out = diff.changed_rows()
+        assert len(out) == 2
+        assert out["category_A"].tolist() == ["B", "C"]
+        assert out["category_B"].tolist() == ["X", "C"]
+        assert out["score_A"].tolist() == [2, 3]
+        assert out["score_B"].tolist() == [2, 9]
+
+    def test_field_filter_only_considers_that_field(self):
+        df_a = pd.DataFrame({"category": ["A", "B"], "score": [1, 2]})
+        df_b = pd.DataFrame({"category": ["A", "X"], "score": [9, 2]})
+        a = _result(df_a, {"category": {}, "score": {"type": "Number"}})
+        b = _result(df_b, {"category": {}, "score": {"type": "Number"}})
+        diff = compare(a, b)
+
+        by_category = diff.changed_rows("category")
+        assert list(by_category.columns) == ["category_A", "category_B"]
+        assert len(by_category) == 1
+        assert by_category["category_A"].tolist() == ["B"]
+
+        by_score = diff.changed_rows("score")
+        assert list(by_score.columns) == ["score_A", "score_B"]
+        assert len(by_score) == 1
+        assert by_score["score_A"].tolist() == [1]
+
+    def test_unknown_field_raises_key_error(self):
+        df = pd.DataFrame({"x": [1]})
+        a, b = _result(df, {"x": {}}), _result(df.copy(), {"x": {}})
+        diff = compare(a, b)
+        with pytest.raises(KeyError):
+            diff.changed_rows("nope")
+
+    def test_error_on_one_side_only_counts_as_changed(self):
+        # Both sides have the same value for the row, but A errored on
+        # row 0 -- that row must still be flagged as a change.
+        df_a = pd.DataFrame({"x": [None, "same"]})
+        df_b = pd.DataFrame({"x": [None, "same"]})
+        err = RowError(row_index=0, step_name="s", error=ValueError("x"))
+        a = _result(df_a, {"x": {}}, errors=[err])
+        b = _result(df_b, {"x": {}})
+        diff = compare(a, b)
+        out = diff.changed_rows()
+        assert len(out) == 1
+
+    def test_identical_with_errors_on_both_sides_same_row_not_flagged(self):
+        df_a = pd.DataFrame({"x": [None, "same"]})
+        df_b = pd.DataFrame({"x": [None, "same"]})
+        err_a = RowError(row_index=0, step_name="s", error=ValueError("x"))
+        err_b = RowError(row_index=0, step_name="s", error=ValueError("y"))
+        a = _result(df_a, {"x": {}}, errors=[err_a])
+        b = _result(df_b, {"x": {}}, errors=[err_b])
+        diff = compare(a, b)
+        out = diff.changed_rows()
+        assert out.empty

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -596,3 +596,20 @@ class TestReport:
         diff = compare(a, b)
         out = diff.report(output_format="html")
         assert "<script>alert(1)</script>" not in out
+
+
+# -- public exports ---------------------------------------------------------------
+
+
+class TestPublicExports:
+    def test_compare_is_top_level_callable(self):
+        import accrue
+
+        assert callable(accrue.compare)
+        assert accrue.ComparisonResult is ComparisonResult
+
+    def test_exported_from_pipeline_namespace(self):
+        from accrue import pipeline
+
+        assert callable(pipeline.compare)
+        assert pipeline.ComparisonResult is ComparisonResult

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -478,3 +478,64 @@ class TestCostDelta:
         delta = diff.cost_delta()
         field_names = {f.name for f in dataclasses.fields(delta)}
         assert not any("dollar" in n or n.startswith("$") or "price" in n for n in field_names)
+
+
+# -- summary() --------------------------------------------------------------------
+
+
+class TestSummary:
+    def test_identical_runs_short_circuit_to_no_differences(self):
+        df = pd.DataFrame({"category": ["A", "B"]})
+        a = _result(df, {"category": {"enum": ["A", "B"]}})
+        b = _result(df.copy(), {"category": {"enum": ["A", "B"]}})
+        diff = compare(a, b, label_a="v1", label_b="v2")
+        out = diff.summary()
+
+        assert "No differences detected" in out
+        assert "0 rows changed" in out
+        assert "2 rows identical" in out
+        # No per-field/cost sections on the early-return path.
+        assert "Per-field churn" not in out
+        assert "Cost delta" not in out
+
+    def test_header_shows_labels_and_models_not_prompt_rev(self):
+        df = pd.DataFrame({"score": [1, 2]})
+        cost_a = CostSummary(steps={"s": StepUsage(model="gpt-4.1-mini")})
+        cost_b = CostSummary(steps={"s": StepUsage(model="gpt-4.1-mini")})
+        a = _result(df, {"score": {"type": "Number"}}, cost=cost_a)
+        b = _result(pd.DataFrame({"score": [1, 5]}), {"score": {"type": "Number"}}, cost=cost_b)
+        diff = compare(a, b, label_a="v1", label_b="v2")
+        out = diff.summary()
+
+        assert "v1" in out and "v2" in out
+        assert "gpt-4.1-mini" in out
+        assert "prompt-rev" not in out
+
+    def test_includes_totals_and_per_field_churn_and_cost_delta(self):
+        df_a = pd.DataFrame({"category": ["AI", "Other"], "score": [1, 2]})
+        df_b = pd.DataFrame({"category": ["AI", "AI"], "score": [1, 9]})
+        a = _result(
+            df_a,
+            {"category": {"enum": ["AI", "Other"]}, "score": {"type": "Number"}},
+            cost=CostSummary(total_tokens=100),
+        )
+        b = _result(
+            df_b,
+            {"category": {"enum": ["AI", "Other"]}, "score": {"type": "Number"}},
+            cost=CostSummary(total_tokens=150),
+        )
+        diff = compare(a, b)
+        out = diff.summary()
+
+        assert "2 rows compared" in out
+        assert "1 rows changed in at least one field" in out
+        assert "Per-field churn" in out
+        assert "category" in out
+        assert "score" in out
+        assert "Cost delta" in out
+
+    def test_ends_with_newline(self):
+        df = pd.DataFrame({"x": [1]})
+        a, b = _result(df, {"x": {}}), _result(df.copy(), {"x": {}})
+        diff = compare(a, b)
+        assert diff.summary().endswith("\n")

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -539,3 +539,60 @@ class TestSummary:
         a, b = _result(df, {"x": {}}), _result(df.copy(), {"x": {}})
         diff = compare(a, b)
         assert diff.summary().endswith("\n")
+
+
+# -- report() ---------------------------------------------------------------------
+
+
+class TestReport:
+    def test_default_markdown_matches_summary(self):
+        df_a = pd.DataFrame({"x": [1, 2]})
+        df_b = pd.DataFrame({"x": [1, 9]})
+        a, b = _result(df_a, {"x": {"type": "Number"}}), _result(df_b, {"x": {"type": "Number"}})
+        diff = compare(a, b)
+        assert diff.report() == diff.summary()
+
+    def test_html_format_is_self_contained(self):
+        df_a = pd.DataFrame({"category": ["A", "B"]})
+        df_b = pd.DataFrame({"category": ["A", "C"]})
+        a = _result(df_a, {"category": {"enum": ["A", "B", "C"]}})
+        b = _result(df_b, {"category": {"enum": ["A", "B", "C"]}})
+        diff = compare(a, b)
+        out = diff.report(output_format="html")
+        assert out.startswith("<!doctype html>")
+        assert "</body></html>" in out
+        assert "Pipeline Comparison Report" in out
+        assert "category" in out
+
+    def test_html_identical_runs(self):
+        df = pd.DataFrame({"x": [1]})
+        a, b = _result(df, {"x": {}}), _result(df.copy(), {"x": {}})
+        diff = compare(a, b)
+        out = diff.report(output_format="html")
+        assert "No differences detected" in out
+
+    def test_unknown_format_raises(self):
+        df = pd.DataFrame({"x": [1]})
+        a, b = _result(df, {"x": {}}), _result(df.copy(), {"x": {}})
+        diff = compare(a, b)
+        with pytest.raises(ValueError, match="Unknown report format"):
+            diff.report(output_format="json")
+
+    def test_path_writes_file(self, tmp_path):
+        df_a = pd.DataFrame({"x": [1, 2]})
+        df_b = pd.DataFrame({"x": [1, 9]})
+        a, b = _result(df_a, {"x": {"type": "Number"}}), _result(df_b, {"x": {"type": "Number"}})
+        diff = compare(a, b)
+        target = tmp_path / "diff.html"
+        out = diff.report(output_format="html", path=str(target))
+        assert target.exists()
+        assert target.read_text(encoding="utf-8") == out
+
+    def test_html_escapes_dangerous_field_values(self):
+        df_a = pd.DataFrame({"category": ["<script>alert(1)</script>"]})
+        df_b = pd.DataFrame({"category": ["safe"]})
+        a = _result(df_a, {"category": {"enum": ["<script>alert(1)</script>", "safe"]}})
+        b = _result(df_b, {"category": {"enum": ["<script>alert(1)</script>", "safe"]}})
+        diff = compare(a, b)
+        out = diff.report(output_format="html")
+        assert "<script>alert(1)</script>" not in out


### PR DESCRIPTION
## Summary

Adds top-level `accrue.compare(result_a, result_b)` → `ComparisonResult` — diff two `PipelineResult` runs (e.g. before/after a prompt tweak) with no labels and no metric setup. Closes #36.

```python
diff = accrue.compare(result_a, result_b, label_a="v1", label_b="v2")
diff.changed_rows()         # rows where any output field differs
diff.distribution_shift()   # enum/numeric field churn
diff.cost_delta()           # token / cache-hit-rate / latency deltas
diff.summary()              # Markdown summary
diff.report(output_format="html", path="v1-vs-v2.html")
```

## Changes (8 logical commits)
- New `accrue/pipeline/compare.py` (`compare()` + `ComparisonResult`), exported from both `__init__.py`.
- `tests/test_compare.py` (52 cases), `docs/guides/compare.md`, README bullet.
- Reuses `report.py`'s render primitives verbatim — **no new dependency** (accrue minimal-deps invariant).

## Notable design calls (full rationale in the #36 plan comment)
- **`cost_delta()` reports tokens / cache-hit-rate / latency — no `$`.** There is no pricing data anywhere in the codebase; hard-coding a price table was rejected as out-of-scope drift.
- **Two correctness foundations built first:** an explicit index-alignment contract (positional-vs-label, uniqueness assertion, positional fallback on mixed/duplicate indexes) and a null-/unhashable-safe `_cells_equal` (both-null-equal, repr/json fallback for container cells) — `NaN != NaN` would otherwise report identical runs as 100% changed, and JSON/list cells raise on `==`.
- `_confidence` / #35 deliberately **not** implemented (trust-signal work hasn't landed; out of scope).
- Honors the issue's out-of-scope list (no stat-sig testing, no semantic similarity, pairwise only).

## Testing
- `ruff check` + `ruff format --check` clean (two separate gates); `pytest` 729 passed / 1 pre-existing skip, incl. the new 52-case compare suite.

---

> **Provenance:** authored end-to-end by the `agentic-sdlc` pipeline (plan → work → simplify → verify) as a real-world validation run. Opened as a **draft, no auto-merge** — for human review. The `simplify` phase's `code-simplifier` correctly preserved the four deliberate correctness guards against its own "unused/redundant" flags (drift tripwire working as designed).