### PR TITLE
fix(cost): count Anthropic cache tokens in usage reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`Pipeline.execute()` returns a 4-tuple** `(accumulated, errors, cost, step_elapsed_seconds)` instead of a 3-tuple. Internal API (not exported in `accrue.__all__`); callers using `Pipeline.run()` / `run_async()` are unaffected.
 
 ### Fixed
+- Anthropic: `cache_creation_input_tokens` and `cache_read_input_tokens` are now carried through `UsageInfo`, `StepUsage`, and `CostSummary`, and counted in `total_tokens`. Cost reports previously omitted prompt-cache tokens, under-reporting the bill by up to ~63x on cached workloads. The pipeline summary now shows cache write/read totals so silent prompt-cache failures are visible. (#108)
 - `LLMStep.parse_response` now strips markdown code fences before `json.loads`. Fixes parse failures with Claude Haiku + grounding tools, where the structured-output constraint is disabled and the model wraps JSON in ` ``` ` fences. (#7)
 - `accrue/__init__.py` `__version__` was out of sync with `pyproject.toml`.
 - Google provider: Option-B rate-limit fallback now uses a word-boundary regex (`\brate[\s_-]?limit\b`) instead of bare `"rate" in exc_str`, preventing false positives on words like "iterate" or "accelerator". (#80)

--- a/accrue/pipeline/pipeline.py
+++ b/accrue/pipeline/pipeline.py
@@ -194,9 +194,16 @@ class PipelineResult:
             for name, usage in self.cost.steps.items():
                 mode = f" {DIM}(batch){RESET}" if usage.execution_mode == "batch" else ""
                 cache_info = ""
-                if usage.cache_hits > 0:
+                has_cache_tokens = usage.cache_write_tokens > 0 or usage.cache_read_tokens > 0
+                if usage.cache_hits > 0 or has_cache_tokens:
                     pct = usage.cache_hit_rate * 100
-                    cache_info = f"  {DIM}cache: {pct:.0f}%{RESET}"
+                    cache_info = f"  {DIM}cache: {pct:.0f}%"
+                    if has_cache_tokens:
+                        cache_info += (
+                            f"  {usage.cache_write_tokens:,} write / "
+                            f"{usage.cache_read_tokens:,} read"
+                        )
+                    cache_info += RESET
                 skip_info = ""
                 if usage.rows_skipped > 0:
                     skip_info = f"  {DIM}skipped: {usage.rows_skipped}{RESET}"
@@ -219,7 +226,9 @@ class PipelineResult:
         lines.append(
             f"  {DIM}tokens:{RESET} {token_str} total  "
             f"{DIM}({self.cost.total_prompt_tokens:,} in / "
-            f"{self.cost.total_completion_tokens:,} out){RESET}"
+            f"{self.cost.total_completion_tokens:,} out / "
+            f"{self.cost.total_cache_write_tokens:,} cache write / "
+            f"{self.cost.total_cache_read_tokens:,} cache read){RESET}"
         )
 
         # Errors
@@ -932,6 +941,8 @@ class Pipeline:
         cost = CostSummary(
             total_prompt_tokens=sum(s.prompt_tokens for s in step_usage_map.values()),
             total_completion_tokens=sum(s.completion_tokens for s in step_usage_map.values()),
+            total_cache_write_tokens=sum(s.cache_write_tokens for s in step_usage_map.values()),
+            total_cache_read_tokens=sum(s.cache_read_tokens for s in step_usage_map.values()),
             total_tokens=sum(s.total_tokens for s in step_usage_map.values()),
             steps=step_usage_map,
         )
@@ -1251,6 +1262,8 @@ class Pipeline:
             step_usage = StepUsage(
                 prompt_tokens=sum(u.prompt_tokens for u in usage_list),
                 completion_tokens=sum(u.completion_tokens for u in usage_list),
+                cache_write_tokens=sum(u.cache_write_tokens for u in usage_list),
+                cache_read_tokens=sum(u.cache_read_tokens for u in usage_list),
                 total_tokens=sum(u.total_tokens for u in usage_list),
                 rows_processed=rows_processed,
                 rows_skipped=rows_skipped,
@@ -1631,6 +1644,8 @@ class Pipeline:
             step_usage = StepUsage(
                 prompt_tokens=sum(u.prompt_tokens for u in usage_list),
                 completion_tokens=sum(u.completion_tokens for u in usage_list),
+                cache_write_tokens=sum(u.cache_write_tokens for u in usage_list),
+                cache_read_tokens=sum(u.cache_read_tokens for u in usage_list),
                 total_tokens=sum(u.total_tokens for u in usage_list),
                 rows_processed=rows_processed,
                 rows_skipped=rows_skipped,

--- a/accrue/pipeline/plan.py
+++ b/accrue/pipeline/plan.py
@@ -152,6 +152,8 @@ def extrapolate_cost(sample_cost: CostSummary, total_rows: int) -> CostSummary:
             scaled = StepUsage(
                 prompt_tokens=round(usage.prompt_tokens * factor),
                 completion_tokens=round(usage.completion_tokens * factor),
+                cache_write_tokens=round(usage.cache_write_tokens * factor),
+                cache_read_tokens=round(usage.cache_read_tokens * factor),
                 total_tokens=round(usage.total_tokens * factor),
                 rows_processed=total_rows,
                 cache_misses=total_rows,
@@ -160,6 +162,8 @@ def extrapolate_cost(sample_cost: CostSummary, total_rows: int) -> CostSummary:
         est.steps[name] = scaled
         est.total_prompt_tokens += scaled.prompt_tokens
         est.total_completion_tokens += scaled.completion_tokens
+        est.total_cache_write_tokens += scaled.cache_write_tokens
+        est.total_cache_read_tokens += scaled.cache_read_tokens
         est.total_tokens += scaled.total_tokens
     return est
 

--- a/accrue/schemas/base.py
+++ b/accrue/schemas/base.py
@@ -9,14 +9,18 @@ class UsageInfo(BaseModel):
     Attributes:
         prompt_tokens: Number of tokens in the prompt/input.
         completion_tokens: Number of tokens in the completion/output.
-        total_tokens: Sum of prompt and completion tokens.
+        total_tokens: Sum of prompt, completion, and cache tokens.
         model: Model identifier that served the request.
+        cache_write_tokens: Tokens written to the prompt cache.
+        cache_read_tokens: Tokens read from the prompt cache.
     """
 
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
     model: str = ""
+    cache_write_tokens: int = 0
+    cache_read_tokens: int = 0
 
 
 class StepUsage(BaseModel):
@@ -25,17 +29,21 @@ class StepUsage(BaseModel):
     Attributes:
         prompt_tokens: Total prompt tokens across all rows in this step.
         completion_tokens: Total completion tokens across all rows.
-        total_tokens: Sum of prompt and completion tokens.
+        total_tokens: Sum of prompt, completion, and cache tokens.
         rows_processed: Number of rows executed (cache hits + misses).
         rows_skipped: Rows skipped by ``run_if``/``skip_if`` predicates.
         model: Model identifier used by this step.
         cache_hits: Rows served from the SQLite cache.
         cache_misses: Rows that required a fresh LLM/function call.
+        cache_write_tokens: Total cache-write tokens across all rows.
+        cache_read_tokens: Total cache-read tokens across all rows.
     """
 
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
+    cache_write_tokens: int = 0
+    cache_read_tokens: int = 0
     rows_processed: int = 0
     rows_skipped: int = 0
     model: str = ""
@@ -60,9 +68,13 @@ class CostSummary(BaseModel):
         total_completion_tokens: Sum of completion tokens across all steps.
         total_tokens: Sum of all tokens across all steps.
         steps: Per-step usage breakdown keyed by step name.
+        total_cache_write_tokens: Sum of cache-write tokens across all steps.
+        total_cache_read_tokens: Sum of cache-read tokens across all steps.
     """
 
     total_prompt_tokens: int = 0
     total_completion_tokens: int = 0
     total_tokens: int = 0
+    total_cache_write_tokens: int = 0
+    total_cache_read_tokens: int = 0
     steps: dict[str, StepUsage] = {}

--- a/accrue/steps/providers/anthropic.py
+++ b/accrue/steps/providers/anthropic.py
@@ -170,10 +170,15 @@ class AnthropicClient:
 
         usage = None
         if response.usage:
+            u = response.usage
+            cache_write = getattr(u, "cache_creation_input_tokens", 0) or 0
+            cache_read = getattr(u, "cache_read_input_tokens", 0) or 0
             usage = UsageInfo(
-                prompt_tokens=response.usage.input_tokens,
-                completion_tokens=response.usage.output_tokens,
-                total_tokens=response.usage.input_tokens + response.usage.output_tokens,
+                prompt_tokens=u.input_tokens,
+                completion_tokens=u.output_tokens,
+                cache_write_tokens=cache_write,
+                cache_read_tokens=cache_read,
+                total_tokens=u.input_tokens + u.output_tokens + cache_write + cache_read,
                 model=model,
             )
 
@@ -353,10 +358,15 @@ class AnthropicClient:
                 content = _extract_text(message)
                 usage = None
                 if message.usage:
+                    u = message.usage
+                    cache_write = getattr(u, "cache_creation_input_tokens", 0) or 0
+                    cache_read = getattr(u, "cache_read_input_tokens", 0) or 0
                     usage = UsageInfo(
-                        prompt_tokens=message.usage.input_tokens,
-                        completion_tokens=message.usage.output_tokens,
-                        total_tokens=message.usage.input_tokens + message.usage.output_tokens,
+                        prompt_tokens=u.input_tokens,
+                        completion_tokens=u.output_tokens,
+                        cache_write_tokens=cache_write,
+                        cache_read_tokens=cache_read,
+                        total_tokens=u.input_tokens + u.output_tokens + cache_write + cache_read,
                         model=message.model,
                     )
                 responses[custom_id] = LLMResponse(content=content, usage=usage)

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -44,6 +44,8 @@ The provider is auto-detected from the `claude-` model prefix. No explicit `clie
 
 **Prompt caching:** Accrue automatically adds `cache_control: {"type": "ephemeral"}` to system messages. On repeated calls with the same system prompt, Anthropic caches the prompt tokens for roughly 90% savings on system prompt input costs. No configuration required.
 
+**Cache token accounting:** Anthropic reports cache-creation and cache-read tokens separately from `input_tokens`. Accrue carries them as `cache_write_tokens` and `cache_read_tokens` on `UsageInfo`, aggregates them into `StepUsage` and `CostSummary`, and counts them in `total_tokens`, so cost reports reflect the real bill. The three input classes are priced differently (1.0x base input, 1.25x cache write, 0.1x cache read), so the cache fields stay separate from `prompt_tokens`. Providers and models that do not report cache tokens simply yield zeros.
+
 **Structured outputs:** Uses constrained decoding (the Anthropic equivalent of `json_schema`). Auto-detected when using dict fields.
 
 ## Google

--- a/tests/test_batch_anthropic.py
+++ b/tests/test_batch_anthropic.py
@@ -55,7 +55,12 @@ def _make_succeeded_entry(custom_id: str, content: str = '{"result": "ok"}'):
             type="succeeded",
             message=SimpleNamespace(
                 content=[SimpleNamespace(type="text", text=content)],
-                usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+                usage=SimpleNamespace(
+                    input_tokens=10,
+                    output_tokens=5,
+                    cache_creation_input_tokens=200,
+                    cache_read_input_tokens=7,
+                ),
                 model="claude-sonnet-4-20250514",
             ),
         ),
@@ -188,6 +193,12 @@ class TestAnthropicPollBatch:
         assert len(result.responses) == 2
         assert result.responses["row-0"].content == '{"market_size": "$5B"}'
         assert result.failed_ids == []
+
+        # Cache tokens flow through the batch usage into total_tokens.
+        usage = result.responses["row-0"].usage
+        assert usage.cache_write_tokens == 200
+        assert usage.cache_read_tokens == 7
+        assert usage.total_tokens == 10 + 5 + 200 + 7
 
     @pytest.mark.asyncio
     async def test_timeout_raises(self):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -281,21 +281,27 @@ class TestCostAggregation:
 
     @pytest.mark.asyncio
     async def test_cost_from_step_with_usage(self):
-        """Step that returns usage info gets aggregated."""
+        """Step that returns usage info gets aggregated, cache tokens included."""
         from accrue.schemas.base import UsageInfo
 
         class UsageStep:
             name = "llm_mock"
             fields = ["f1"]
             depends_on = []
+            _call = 0
 
             async def run(self, ctx):
+                self._call += 1
+                cache_write = 100 if self._call == 1 else 200
+                cache_read = 50 if self._call == 1 else 100
                 return StepResult(
                     values={"f1": "val"},
                     usage=UsageInfo(
                         prompt_tokens=100,
                         completion_tokens=50,
-                        total_tokens=150,
+                        cache_write_tokens=cache_write,
+                        cache_read_tokens=cache_read,
+                        total_tokens=150 + cache_write + cache_read,
                         model="test-model",
                     ),
                 )
@@ -307,9 +313,14 @@ class TestCostAggregation:
         )
         assert cost.total_prompt_tokens == 200
         assert cost.total_completion_tokens == 100
-        assert cost.total_tokens == 300
+        # Row 1: 100 write / 50 read; row 2: 200 write / 100 read.
+        assert cost.total_cache_write_tokens == 300
+        assert cost.total_cache_read_tokens == 150
+        assert cost.total_tokens == 750
         assert "llm_mock" in cost.steps
         assert cost.steps["llm_mock"].rows_processed == 2
+        assert cost.steps["llm_mock"].cache_write_tokens == 300
+        assert cost.steps["llm_mock"].cache_read_tokens == 150
         assert cost.steps["llm_mock"].model == "test-model"
 
 

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -52,19 +52,32 @@ def _fresh_config(tmp_path) -> EnrichmentConfig:
 
 class TestExtrapolateCost:
     def test_scales_by_executed_rows(self):
-        sample = CostSummary(total_prompt_tokens=300, total_completion_tokens=150, total_tokens=450)
+        sample = CostSummary(
+            total_prompt_tokens=300,
+            total_completion_tokens=150,
+            total_tokens=450,
+            total_cache_write_tokens=1000,
+            total_cache_read_tokens=200,
+        )
         sample.steps["s"] = StepUsage(
             prompt_tokens=300,
             completion_tokens=150,
             total_tokens=450,
             rows_processed=3,
             cache_misses=3,
+            cache_write_tokens=1000,
+            cache_read_tokens=200,
         )
         est = extrapolate_cost(sample, total_rows=30)
         # 3 executed rows → 100/50 per row → ×30
         assert est.total_prompt_tokens == 3000
         assert est.total_completion_tokens == 1500
         assert est.total_tokens == 4500
+        # Cache tokens scale with the same factor: 1000/3 → ×30
+        assert est.total_cache_write_tokens == 10000
+        assert est.total_cache_read_tokens == 2000
+        assert est.steps["s"].cache_write_tokens == 10000
+        assert est.steps["s"].cache_read_tokens == 2000
 
     def test_cached_rows_not_double_charged(self):
         # 3 rows processed but only 2 actually called the API (1 cache hit).

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -639,7 +639,12 @@ class TestAnthropicClient:
 
         mock_response = SimpleNamespace(
             content=[SimpleNamespace(text='{"f1": "val"}', type="text", citations=None)],
-            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+            usage=SimpleNamespace(
+                input_tokens=10,
+                output_tokens=5,
+                cache_creation_input_tokens=7,
+                cache_read_input_tokens=3,
+            ),
         )
         mock_inner = MagicMock()
         mock_inner.messages.create = AsyncMock(return_value=mock_response)
@@ -660,6 +665,70 @@ class TestAnthropicClient:
         assert call_kwargs["output_config"]["format"]["type"] == "json_schema"
         assert call_kwargs["output_config"]["format"]["schema"] == schema
         assert result.content == '{"f1": "val"}'
+        assert result.usage.total_tokens == 25
+        assert result.usage.cache_write_tokens == 7
+        assert result.usage.cache_read_tokens == 3
+
+    @pytest.mark.asyncio
+    async def test_cache_tokens_included_in_total_tokens(self):
+        """Issue #108: cache tokens are carried into UsageInfo and summed in total_tokens."""
+        self._install_mock_anthropic()
+        from accrue.steps.providers.anthropic import AnthropicClient
+
+        mock_response = SimpleNamespace(
+            content=[SimpleNamespace(text="ok", type="text", citations=None)],
+            usage=SimpleNamespace(
+                input_tokens=120,
+                output_tokens=1420,
+                cache_creation_input_tokens=95537,
+                cache_read_input_tokens=0,
+            ),
+        )
+        mock_inner = MagicMock()
+        mock_inner.messages.create = AsyncMock(return_value=mock_response)
+
+        client = AnthropicClient(api_key="test")
+        client._client = mock_inner
+
+        result = await client.complete(
+            messages=[{"role": "user", "content": "hi"}],
+            model="claude-sonnet-5",
+            temperature=0.2,
+            max_tokens=1000,
+        )
+
+        assert result.usage.prompt_tokens == 120
+        assert result.usage.completion_tokens == 1420
+        assert result.usage.cache_write_tokens == 95537
+        assert result.usage.cache_read_tokens == 0
+        assert result.usage.total_tokens == 97077
+
+    @pytest.mark.asyncio
+    async def test_missing_cache_fields_default_to_zero(self):
+        """Usage without cache fields still produces total_tokens = input + output."""
+        self._install_mock_anthropic()
+        from accrue.steps.providers.anthropic import AnthropicClient
+
+        mock_response = SimpleNamespace(
+            content=[SimpleNamespace(text="ok", type="text", citations=None)],
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        )
+        mock_inner = MagicMock()
+        mock_inner.messages.create = AsyncMock(return_value=mock_response)
+
+        client = AnthropicClient(api_key="test")
+        client._client = mock_inner
+
+        result = await client.complete(
+            messages=[{"role": "user", "content": "hi"}],
+            model="claude-sonnet-4-5-20250929",
+            temperature=0.2,
+            max_tokens=1000,
+        )
+
+        assert result.usage.total_tokens == 15
+        assert result.usage.cache_write_tokens == 0
+        assert result.usage.cache_read_tokens == 0
 
     @pytest.mark.asyncio
     async def test_json_object_ignored(self):


### PR DESCRIPTION
## Summary

The cost report omitted prompt-cache tokens. The Anthropic provider counted only `input_tokens` and `output_tokens`, while the API reports `cache_creation_input_tokens` and `cache_read_input_tokens` separately. On any workload using prompt caching, the cache tokens dominate the input bill, so `result.cost.total_tokens` under-reported by about 63x (measured: 1,540 reported vs 97,077 billed).

## Changes

- Added `cache_write_tokens` and `cache_read_tokens` to `UsageInfo` and `StepUsage`, and totals to `CostSummary`.
- Anthropic provider now reads both cache fields with `getattr` defaults and includes them in `total_tokens`, in both the realtime and batch results paths.
- Pipeline step aggregation sums the cache fields; the summary line now prints cache write and cache read totals, so a silently failing prompt cache is visible.
- `extrapolate_cost` scales the cache fields with the same factor as the other token counts.
- OpenAI and Google providers were checked: their cached-token counts are subsets of the reported prompt tokens, so their totals were already correct and remain unchanged.
- This change was authored with AI assistance.

## Testing

- `pytest`: 731 passed, 1 skipped.
- Regression test reproduces the issue's measured numbers: input 120 + output 1,420 + cache write 95,537 + cache read 0 = 97,077.
- Test for providers that omit the cache fields: totals fall back to input + output.
- `ruff check` and `ruff format --check`: clean.

## Checklist

- [x] Tests pass
- [x] Linting/formatting passes
- [x] Self-reviewed
- [x] Documentation updated (if applicable)

Closes #108

If this helped, RawNuke welcomes sponsorship: https://github.com/sponsors/RawNuke
