### PR TITLE
fix(providers): omit temperature for Anthropic models that reject it (#109)

### DIFF
--- a/accrue/steps/providers/anthropic.py
+++ b/accrue/steps/providers/anthropic.py
@@ -123,10 +123,11 @@ class AnthropicClient:
             max_tokens=max_tokens,
         )
         # Omit temperature for models that reject an explicit value (issue #109).
+        # The warning is deferred until after provider_kwargs is merged below,
+        # so the documented escape hatch does not trigger a "value was dropped"
+        # warning about a value it puts straight back.
         if temperature is not None and _supports_temperature(model):
             kwargs["temperature"] = temperature
-        else:
-            self._warn_temperature_dropped(model, temperature)
 
         if system_content:
             # Prompt caching: wrap system content in a content block with
@@ -177,6 +178,10 @@ class AnthropicClient:
         # like thinking, effort, etc.)
         if provider_kwargs:
             kwargs.update(provider_kwargs)
+
+        # Warn only when no temperature reaches the API at all (issue #109).
+        if "temperature" not in kwargs:
+            self._warn_temperature_dropped(model, temperature)
 
         try:
             from anthropic import APIError, APITimeoutError, RateLimitError
@@ -268,11 +273,10 @@ class AnthropicClient:
                 "max_tokens": req.max_tokens,
                 "messages": chat_messages,
             }
-            # Same temperature rule as the realtime path (issue #109).
+            # Same temperature rule as the realtime path (issue #109), including
+            # deferring the warning until after provider_kwargs is merged below.
             if req.temperature is not None and _supports_temperature(req.model):
                 params["temperature"] = req.temperature
-            else:
-                self._warn_temperature_dropped(req.model, req.temperature)
             if system_content:
                 # Prompt caching for batch requests — same static-prefix
                 # requirement as the realtime path above.
@@ -294,6 +298,10 @@ class AnthropicClient:
             # Forward provider_kwargs (e.g. thinking, effort)
             if req.provider_kwargs:
                 params.update(req.provider_kwargs)
+
+            # Warn only when no temperature reaches the API at all (issue #109).
+            if "temperature" not in params:
+                self._warn_temperature_dropped(req.model, req.temperature)
 
             anthropic_requests.append(
                 {

--- a/accrue/steps/providers/anthropic.py
+++ b/accrue/steps/providers/anthropic.py
@@ -200,10 +200,12 @@ class AnthropicClient:
             ) from exc
         except APIError as exc:
             exc_status = getattr(exc, "status_code", None)
+            # Only claim a temperature problem when we actually sent one.
+            hint = _temperature_hint(model, exc) if "temperature" in kwargs else ""
             # Promote generic 429 to is_rate_limit (covers cases where RateLimitError
             # is not raised but status_code is 429)
             raise LLMAPIError(
-                f"Anthropic API error for model '{model}': {exc}{_temperature_hint(model, exc)}",
+                f"Anthropic API error for model '{model}': {exc}{hint}",
                 status_code=exc_status,
                 is_rate_limit=(exc_status == 429),
             ) from exc
@@ -315,9 +317,16 @@ class AnthropicClient:
             logger.info("Anthropic batch submitted: %s (%d requests)", batch.id, len(requests))
             return batch.id
         except Exception as exc:
+            # Name a model we actually sent a temperature for.  accrue's own
+            # batches are single-model, but submit_batch() is public and a
+            # caller can mix them, so do not assume requests[0] is the culprit.
+            culprit = next(
+                (r["params"]["model"] for r in anthropic_requests if "temperature" in r["params"]),
+                None,
+            )
+            hint = _temperature_hint(culprit, exc) if culprit else ""
             raise LLMAPIError(
-                f"Anthropic batch submission failed: {exc}"
-                f"{_temperature_hint(requests[0].model, exc) if requests else ''}",
+                f"Anthropic batch submission failed: {exc}{hint}",
                 status_code=getattr(exc, "status_code", None),
             ) from exc
 

--- a/accrue/steps/providers/anthropic.py
+++ b/accrue/steps/providers/anthropic.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import time
 from typing import Any
 
@@ -42,6 +43,36 @@ class AnthropicClient:
         # fresh AnthropicClient on each Pipeline.run_async() call, so users see
         # this warning once per pipeline run rather than once per process lifetime.
         self._warned_grounding_schema: bool = False
+        self._warned_temperature_dropped: bool = False
+
+    def _warn_temperature_dropped(self, model: str, temperature: float | None) -> None:
+        """Warn once when a requested temperature is dropped for *model*.
+
+        The adapter cannot tell a user-set value from ``EnrichmentConfig``'s
+        default — both arrive as a plain float — so the trigger is whether the
+        drop actually changes anything.  These models sample at
+        :data:`_IMPLICIT_TEMPERATURE` when the parameter is omitted, so dropping
+        that exact value is a no-op and stays silent.
+
+        Args:
+            model: Model the request is being made against.
+            temperature: The resolved temperature, or ``None`` if none was set.
+        """
+        if temperature is None or temperature == _IMPLICIT_TEMPERATURE:
+            return
+        if self._warned_temperature_dropped:
+            return
+        logger.warning(
+            "Model '%s' does not accept an explicit temperature; the requested "
+            "value %s was dropped and the model's default of %s applies. Set "
+            "temperature=%s to silence this warning, or use a model that supports "
+            "temperature (e.g. claude-sonnet-4-5) if you need deterministic sampling.",
+            model,
+            temperature,
+            _IMPLICIT_TEMPERATURE,
+            _IMPLICIT_TEMPERATURE,
+        )
+        self._warned_temperature_dropped = True
 
     def _get_client(self) -> Any:
         if self._client is None:
@@ -69,7 +100,7 @@ class AnthropicClient:
         self,
         messages: list[dict[str, Any]],
         model: str,
-        temperature: float,
+        temperature: float | None,
         max_tokens: int,
         response_format: dict[str, Any] | None = None,
         tools: list[dict[str, Any]] | None = None,
@@ -89,9 +120,14 @@ class AnthropicClient:
         kwargs: dict[str, Any] = dict(
             model=model,
             messages=chat_messages,
-            temperature=temperature,
             max_tokens=max_tokens,
         )
+        # Omit temperature for models that reject an explicit value (issue #109).
+        if temperature is not None and _supports_temperature(model):
+            kwargs["temperature"] = temperature
+        else:
+            self._warn_temperature_dropped(model, temperature)
+
         if system_content:
             # Prompt caching: wrap system content in a content block with
             # cache_control so Anthropic caches the system prompt prefix.
@@ -162,7 +198,7 @@ class AnthropicClient:
             # Promote generic 429 to is_rate_limit (covers cases where RateLimitError
             # is not raised but status_code is 429)
             raise LLMAPIError(
-                f"Anthropic API error for model '{model}': {exc}",
+                f"Anthropic API error for model '{model}': {exc}{_temperature_hint(model, exc)}",
                 status_code=exc_status,
                 is_rate_limit=(exc_status == 429),
             ) from exc
@@ -230,9 +266,13 @@ class AnthropicClient:
             params: dict[str, Any] = {
                 "model": req.model,
                 "max_tokens": req.max_tokens,
-                "temperature": req.temperature,
                 "messages": chat_messages,
             }
+            # Same temperature rule as the realtime path (issue #109).
+            if req.temperature is not None and _supports_temperature(req.model):
+                params["temperature"] = req.temperature
+            else:
+                self._warn_temperature_dropped(req.model, req.temperature)
             if system_content:
                 # Prompt caching for batch requests — same static-prefix
                 # requirement as the realtime path above.
@@ -268,7 +308,8 @@ class AnthropicClient:
             return batch.id
         except Exception as exc:
             raise LLMAPIError(
-                f"Anthropic batch submission failed: {exc}",
+                f"Anthropic batch submission failed: {exc}"
+                f"{_temperature_hint(requests[0].model, exc) if requests else ''}",
                 status_code=getattr(exc, "status_code", None),
             ) from exc
 
@@ -394,6 +435,64 @@ class AnthropicClient:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+# Anthropic models that reject an explicit ``temperature`` (issue #109).
+#
+# The Claude 5 family and Claude Opus 4.7/4.8 removed the sampling parameters.
+# Any explicit value other than the model's own default returns
+# ``400 - `temperature` is deprecated for this model.``  Omitting the parameter
+# is always accepted, so the fix is to not send it at all.
+#
+# Matched on model-family prefix rather than an exhaustive list of dated model
+# ids, so unreleased Claude 5 variants and vendor-prefixed ids
+# (``anthropic.claude-sonnet-5``, ``us.anthropic.claude-sonnet-5-v1:0``) are
+# covered without a code change.  The first branch requires an alphabetic tier
+# segment between ``claude-`` and the major version, so Claude 3/4 ids that
+# merely contain a 5 do not match: ``claude-3-5-sonnet-20241022`` (digit after
+# ``claude-``), ``claude-sonnet-4-5`` and ``claude-haiku-4-5`` (major version 4).
+_NO_EXPLICIT_TEMPERATURE = re.compile(r"claude-(?:[a-z]+-5|opus-4-[78])(?!\d)")
+
+# The value these models use when ``temperature`` is omitted.  Dropping a
+# request for this exact value changes nothing, so it is not worth warning about.
+_IMPLICIT_TEMPERATURE = 1.0
+
+
+def _supports_temperature(model: str) -> bool:
+    """Whether *model* accepts an explicit ``temperature`` parameter.
+
+    Args:
+        model: Anthropic model identifier, optionally vendor-prefixed.
+
+    Returns:
+        ``False`` for models that reject an explicit value (Claude 5 family,
+        Claude Opus 4.7/4.8), ``True`` otherwise.
+    """
+    return _NO_EXPLICIT_TEMPERATURE.search(model.lower()) is None
+
+
+def _temperature_hint(model: str, exc: Exception) -> str:
+    """Actionable suffix for API errors caused by an unsupported ``temperature``.
+
+    Covers models newer than :func:`_supports_temperature` knows about: the raw
+    SDK message names a model capability, which reads like an API problem rather
+    than an accrue one.
+
+    Args:
+        model: Model the request was made against.
+        exc: The provider exception.
+
+    Returns:
+        A hint string, or ``""`` when the error is unrelated to temperature.
+    """
+    if "temperature" not in str(exc).lower():
+        return ""
+    return (
+        f" — the model '{model}' rejects an explicit temperature. accrue omits it "
+        "automatically for the model families known to have removed it (Claude 5, "
+        f"Claude Opus 4.7/4.8); please report '{model}' at "
+        "https://github.com/matt-house-e/accrue/issues so the check can cover it."
+    )
 
 
 def _translate_tools(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -91,7 +91,7 @@ LLMStep("creative",
 )
 ```
 
-**Some models ignore temperature.** The Claude 5 family and Claude Opus 4.7/4.8 removed the sampling parameters and reject an explicit `temperature` with a 400. The Anthropic adapter omits it for those models, so the resolved value above is silently unused and the model samples at its own default. See [Providers -> Anthropic](providers.md#anthropic).
+**Some models ignore temperature.** The Claude 5 family and Claude Opus 4.7/4.8 removed the sampling parameters and reject an explicit `temperature` with a 400. The Anthropic adapter omits it for those models, so the resolved value above never reaches the API and the model samples at its own default of `1.0`. If the dropped value was anything other than `1.0`, a warning is logged once per pipeline run. See [Providers -> Anthropic](providers.md#anthropic).
 
 ## Concurrency tuning
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -91,6 +91,8 @@ LLMStep("creative",
 )
 ```
 
+**Some models ignore temperature.** The Claude 5 family and Claude Opus 4.7/4.8 removed the sampling parameters and reject an explicit `temperature` with a 400. The Anthropic adapter omits it for those models, so the resolved value above is silently unused and the model samples at its own default. See [Providers -> Anthropic](providers.md#anthropic).
+
 ## Concurrency tuning
 
 The `max_workers` setting controls how many rows are processed concurrently within each step (via `asyncio.Semaphore`). Set it based on your provider's rate limits.

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -72,6 +72,8 @@ Three consequences worth knowing:
 
 **Structured outputs:** Uses constrained decoding (the Anthropic equivalent of `json_schema`). Auto-detected when using dict fields.
 
+**Temperature:** The Claude 5 family (`claude-sonnet-5`, `claude-opus-5`, `claude-fable-5`, ...) and Claude Opus 4.7/4.8 removed the sampling parameters — sending an explicit `temperature` returns `400 - `temperature` is deprecated for this model.`. Accrue omits the parameter for those models automatically, on both the realtime and batch paths, and the model samples at its own default of `1.0`. If the dropped value was something other than `1.0`, a warning is logged once per pipeline run, since the run is no longer sampling at the temperature you configured. Nothing to configure — but if you need low-temperature determinism, use a model that still supports it (e.g. `claude-sonnet-4-5`). To send a temperature anyway, `provider_kwargs={"temperature": ...}` still overrides.
+
 ## Google
 
 ```python

--- a/docs/guides/providers.md
+++ b/docs/guides/providers.md
@@ -72,7 +72,7 @@ Three consequences worth knowing:
 
 **Structured outputs:** Uses constrained decoding (the Anthropic equivalent of `json_schema`). Auto-detected when using dict fields.
 
-**Temperature:** The Claude 5 family (`claude-sonnet-5`, `claude-opus-5`, `claude-fable-5`, ...) and Claude Opus 4.7/4.8 removed the sampling parameters — sending an explicit `temperature` returns `400 - `temperature` is deprecated for this model.`. Accrue omits the parameter for those models automatically, on both the realtime and batch paths, and the model samples at its own default of `1.0`. If the dropped value was something other than `1.0`, a warning is logged once per pipeline run, since the run is no longer sampling at the temperature you configured. Nothing to configure — but if you need low-temperature determinism, use a model that still supports it (e.g. `claude-sonnet-4-5`). To send a temperature anyway, `provider_kwargs={"temperature": ...}` still overrides.
+**Temperature:** The Claude 5 family (`claude-sonnet-5`, `claude-opus-5`, `claude-fable-5`, ...) and Claude Opus 4.7/4.8 removed the sampling parameters — sending an explicit `temperature` returns ``400 - `temperature` is deprecated for this model.`` Accrue omits the parameter for those models automatically, on both the realtime and batch paths, and the model samples at its own default of `1.0`. If the dropped value was something other than `1.0`, a warning is logged once per pipeline run, since the run is no longer sampling at the temperature you configured. Nothing to configure — but if you need low-temperature determinism, use a model that still supports it (e.g. `claude-sonnet-4-5`). To send a temperature anyway, `provider_kwargs={"temperature": ...}` still overrides.
 
 ## Google
 

--- a/tests/test_batch_anthropic.py
+++ b/tests/test_batch_anthropic.py
@@ -212,6 +212,20 @@ class TestAnthropicBatchTemperature:
         assert len(warnings) == 1
 
     @pytest.mark.asyncio
+    async def test_no_warning_when_provider_kwargs_supplies_a_temperature(self, caplog):
+        """Nothing is dropped when the escape hatch puts a temperature back."""
+        import logging
+
+        req = _make_batch_request(0, model="claude-sonnet-5")
+        req.provider_kwargs = {"temperature": 0.9}
+
+        with caplog.at_level(logging.WARNING, logger="accrue.steps.providers.anthropic"):
+            _, params = await self._submit([req])
+
+        assert params[0]["temperature"] == 0.9
+        assert "does not accept an explicit temperature" not in caplog.text
+
+    @pytest.mark.asyncio
     async def test_submit_failure_gains_temperature_hint(self):
         from accrue.steps.providers.anthropic import AnthropicClient
         from accrue.steps.providers.base import LLMAPIError

--- a/tests/test_batch_anthropic.py
+++ b/tests/test_batch_anthropic.py
@@ -241,6 +241,48 @@ class TestAnthropicBatchTemperature:
             await client.submit_batch([_make_batch_request(0, model="claude-sonnet-9")])
 
         assert "rejects an explicit temperature" in str(exc_info.value)
+        assert "claude-sonnet-9" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_hint_names_a_model_we_actually_sent_a_temperature_for(self):
+        """A mixed batch must not blame the first request when it was not the culprit."""
+        from accrue.steps.providers.anthropic import AnthropicClient
+        from accrue.steps.providers.base import LLMAPIError
+
+        mock_inner = MagicMock()
+        mock_inner.messages.batches.create = AsyncMock(
+            side_effect=RuntimeError("`temperature` is deprecated for this model.")
+        )
+        client = AnthropicClient(api_key="test")
+        client._client = mock_inner
+
+        with pytest.raises(LLMAPIError) as exc_info:
+            await client.submit_batch(
+                [
+                    _make_batch_request(0, model="claude-sonnet-5"),  # temperature omitted
+                    _make_batch_request(1, model="claude-sonnet-9"),  # temperature sent
+                ]
+            )
+
+        assert "claude-sonnet-9" in str(exc_info.value)
+        assert "the model 'claude-sonnet-5' rejects" not in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_no_hint_when_no_temperature_was_sent(self):
+        from accrue.steps.providers.anthropic import AnthropicClient
+        from accrue.steps.providers.base import LLMAPIError
+
+        mock_inner = MagicMock()
+        mock_inner.messages.batches.create = AsyncMock(
+            side_effect=RuntimeError("`temperature` is deprecated for this model.")
+        )
+        client = AnthropicClient(api_key="test")
+        client._client = mock_inner
+
+        with pytest.raises(LLMAPIError) as exc_info:
+            await client.submit_batch([_make_batch_request(0, model="claude-sonnet-5")])
+
+        assert "rejects an explicit temperature" not in str(exc_info.value)
 
 
 # -- poll_batch --------------------------------------------------------------

--- a/tests/test_batch_anthropic.py
+++ b/tests/test_batch_anthropic.py
@@ -34,15 +34,19 @@ def patch_anthropic():
 # -- helpers -----------------------------------------------------------------
 
 
-def _make_batch_request(idx: int = 0) -> BatchRequest:
+def _make_batch_request(
+    idx: int = 0,
+    model: str = "claude-sonnet-4-20250514",
+    temperature: float | None = 0.2,
+) -> BatchRequest:
     return BatchRequest(
         custom_id=f"row-{idx}",
         messages=[
             {"role": "system", "content": "You are an assistant."},
             {"role": "user", "content": "Analyze the data."},
         ],
-        model="claude-sonnet-4-20250514",
-        temperature=0.2,
+        model=model,
+        temperature=temperature,
         max_tokens=4000,
         response_format={"type": "json_schema", "json_schema": {"schema": {"type": "object"}}},
     )
@@ -138,6 +142,91 @@ class TestAnthropicSubmitBatch:
         params = call_kwargs["requests"][0]["params"]
         assert "output_config" in params
         assert params["output_config"]["format"]["type"] == "json_schema"
+
+
+# -- submit_batch temperature handling (issue #109) ---------------------------
+
+
+class TestAnthropicBatchTemperature:
+    """The batch path must apply the same temperature rule as the realtime path."""
+
+    @staticmethod
+    def _mock_inner():
+        mock_inner = MagicMock()
+        mock_inner.messages.batches.create = AsyncMock(
+            return_value=SimpleNamespace(id="msgbatch_abc")
+        )
+        return mock_inner
+
+    async def _submit(self, requests):
+        from accrue.steps.providers.anthropic import AnthropicClient
+
+        client = AnthropicClient(api_key="test")
+        client._client = self._mock_inner()
+        await client.submit_batch(requests)
+        submitted = client._client.messages.batches.create.call_args.kwargs["requests"]
+        return client, [r["params"] for r in submitted]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("model", ["claude-sonnet-5", "claude-opus-5", "claude-opus-4-8"])
+    async def test_claude_5_batch_omits_temperature(self, model):
+        _, params = await self._submit([_make_batch_request(0, model=model)])
+
+        assert "temperature" not in params[0]
+        assert params[0]["model"] == model
+        assert params[0]["max_tokens"] == 4000
+
+    @pytest.mark.asyncio
+    async def test_claude_4_batch_keeps_temperature(self):
+        _, params = await self._submit([_make_batch_request(0)])
+
+        assert params[0]["temperature"] == 0.2
+
+    @pytest.mark.asyncio
+    async def test_none_temperature_is_never_sent(self):
+        _, params = await self._submit([_make_batch_request(0, temperature=None)])
+
+        assert "temperature" not in params[0]
+
+    @pytest.mark.asyncio
+    async def test_mixed_models_in_one_batch(self):
+        """The rule is per-request, not per-batch."""
+        _, params = await self._submit(
+            [
+                _make_batch_request(0, model="claude-sonnet-5"),
+                _make_batch_request(1, model="claude-sonnet-4-5"),
+            ]
+        )
+
+        assert "temperature" not in params[0]
+        assert params[1]["temperature"] == 0.2
+
+    @pytest.mark.asyncio
+    async def test_warns_once_per_batch(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="accrue.steps.providers.anthropic"):
+            await self._submit([_make_batch_request(i, model="claude-sonnet-5") for i in range(3)])
+
+        warnings = [r for r in caplog.records if "does not accept an explicit" in r.message]
+        assert len(warnings) == 1
+
+    @pytest.mark.asyncio
+    async def test_submit_failure_gains_temperature_hint(self):
+        from accrue.steps.providers.anthropic import AnthropicClient
+        from accrue.steps.providers.base import LLMAPIError
+
+        mock_inner = MagicMock()
+        mock_inner.messages.batches.create = AsyncMock(
+            side_effect=RuntimeError("`temperature` is deprecated for this model.")
+        )
+        client = AnthropicClient(api_key="test")
+        client._client = mock_inner
+
+        with pytest.raises(LLMAPIError) as exc_info:
+            await client.submit_batch([_make_batch_request(0, model="claude-sonnet-9")])
+
+        assert "rejects an explicit temperature" in str(exc_info.value)
 
 
 # -- poll_batch --------------------------------------------------------------

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1417,6 +1417,16 @@ class TestAnthropicTemperature:
         assert "rejects an explicit temperature" not in str(exc_info.value)
         assert "credit balance too low" in str(exc_info.value)
 
+    @pytest.mark.asyncio
+    async def test_no_hint_when_no_temperature_was_sent(self):
+        """A temperature error we did not cause must not be blamed on our knob."""
+        with pytest.raises(LLMAPIError) as exc_info:
+            await self._complete_raising(
+                "claude-sonnet-5", "`temperature` is deprecated for this model."
+            )
+
+        assert "rejects an explicit temperature" not in str(exc_info.value)
+
 
 # -- GoogleClient -----------------------------------------------------------
 

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1271,6 +1271,26 @@ class TestAnthropicTemperature:
         assert call_kwargs["temperature"] == 1.0
 
     @pytest.mark.asyncio
+    async def test_no_warning_when_provider_kwargs_supplies_a_temperature(self, caplog):
+        """Nothing is dropped when the escape hatch puts a temperature back."""
+        TestAnthropicClient._install_mock_anthropic()
+        from accrue.steps.providers.anthropic import AnthropicClient
+
+        client = AnthropicClient(api_key="test")
+        client._client = self._mock_inner()
+        with caplog.at_level(logging.WARNING, logger="accrue.steps.providers.anthropic"):
+            await client.complete(
+                messages=[{"role": "user", "content": "hi"}],
+                model="claude-sonnet-5",
+                temperature=0.2,
+                max_tokens=1000,
+                provider_kwargs={"temperature": 0.9},
+            )
+
+        assert client._client.messages.create.call_args.kwargs["temperature"] == 0.9
+        assert "does not accept an explicit temperature" not in caplog.text
+
+    @pytest.mark.asyncio
     async def test_warns_once_when_a_meaningful_value_is_dropped(self, caplog):
         TestAnthropicClient._install_mock_anthropic()
         from accrue.steps.providers.anthropic import AnthropicClient

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1150,6 +1150,254 @@ class TestAnthropicClient:
         assert "structured output schema will not be enforced" in caplog.text
 
 
+# -- AnthropicClient temperature handling (issue #109) -----------------------
+
+
+# Models that removed the sampling parameters: any explicit temperature 400s.
+NO_TEMPERATURE_MODELS = [
+    "claude-sonnet-5",
+    "claude-opus-5",
+    "claude-fable-5",
+    "claude-mythos-5",
+    "claude-sonnet-5-20260101",  # hypothetical dated snapshot
+    "claude-opus-5-1",  # hypothetical point release
+    "anthropic.claude-sonnet-5",  # Bedrock-style vendor prefix
+    "us.anthropic.claude-sonnet-5-v1:0",
+    "Claude-Sonnet-5",  # case-insensitive
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+]
+
+# Models that still accept an explicit temperature.  Several of these contain a
+# "5" and are the regression cases the family-prefix match must not swallow.
+TEMPERATURE_MODELS = [
+    "claude-3-5-sonnet-20241022",
+    "claude-3-5-haiku-20241022",
+    "claude-sonnet-4-5",
+    "claude-sonnet-4-5-20250929",
+    "claude-haiku-4-5",
+    "claude-opus-4-5-20251101",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-3-opus-20240229",
+    "claude-opus-4-1-20250805",
+    "claude-sonnet-4-20250514",
+]
+
+
+class TestSupportsTemperature:
+    """The model-family predicate behind the temperature omission."""
+
+    @pytest.mark.parametrize("model", NO_TEMPERATURE_MODELS)
+    def test_rejects_models_without_temperature_support(self, model):
+        from accrue.steps.providers.anthropic import _supports_temperature
+
+        assert _supports_temperature(model) is False
+
+    @pytest.mark.parametrize("model", TEMPERATURE_MODELS)
+    def test_allows_models_with_temperature_support(self, model):
+        from accrue.steps.providers.anthropic import _supports_temperature
+
+        assert _supports_temperature(model) is True
+
+
+class TestAnthropicTemperature:
+    """Issue #109: Claude 5 (and Opus 4.7/4.8) 400 on an explicit temperature."""
+
+    @staticmethod
+    def _mock_inner():
+        mock_response = SimpleNamespace(
+            content=[SimpleNamespace(text='{"f1": "val"}', type="text", citations=None)],
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5),
+        )
+        mock_inner = MagicMock()
+        mock_inner.messages.create = AsyncMock(return_value=mock_response)
+        return mock_inner
+
+    async def _complete(self, model, temperature, mock_inner=None):
+        TestAnthropicClient._install_mock_anthropic()
+        from accrue.steps.providers.anthropic import AnthropicClient
+
+        client = AnthropicClient(api_key="test")
+        client._client = mock_inner or self._mock_inner()
+        await client.complete(
+            messages=[{"role": "user", "content": "hi"}],
+            model=model,
+            temperature=temperature,
+            max_tokens=1000,
+        )
+        return client, client._client.messages.create.call_args.kwargs
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("model", ["claude-sonnet-5", "claude-opus-5", "claude-fable-5"])
+    async def test_claude_5_receives_no_temperature(self, model):
+        """The reported failure: no temperature reaches the API for Claude 5."""
+        _, call_kwargs = await self._complete(model, 0.2)
+
+        assert "temperature" not in call_kwargs
+        assert call_kwargs["model"] == model
+        assert call_kwargs["max_tokens"] == 1000
+
+    @pytest.mark.asyncio
+    async def test_claude_4_still_receives_temperature(self):
+        _, call_kwargs = await self._complete("claude-sonnet-4-5-20250929", 0.2)
+
+        assert call_kwargs["temperature"] == 0.2
+
+    @pytest.mark.asyncio
+    async def test_none_temperature_is_never_sent(self):
+        """``None`` means "do not send" even on a model that supports it."""
+        _, call_kwargs = await self._complete("claude-sonnet-4-5-20250929", None)
+
+        assert "temperature" not in call_kwargs
+
+    @pytest.mark.asyncio
+    async def test_provider_kwargs_can_still_force_temperature(self):
+        """The documented escape hatch wins over the automatic omission."""
+        TestAnthropicClient._install_mock_anthropic()
+        from accrue.steps.providers.anthropic import AnthropicClient
+
+        client = AnthropicClient(api_key="test")
+        client._client = self._mock_inner()
+        await client.complete(
+            messages=[{"role": "user", "content": "hi"}],
+            model="claude-sonnet-5",
+            temperature=0.2,
+            max_tokens=1000,
+            provider_kwargs={"temperature": 1.0},
+        )
+
+        call_kwargs = client._client.messages.create.call_args.kwargs
+        assert call_kwargs["temperature"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_warns_once_when_a_meaningful_value_is_dropped(self, caplog):
+        TestAnthropicClient._install_mock_anthropic()
+        from accrue.steps.providers.anthropic import AnthropicClient
+
+        mock_inner = self._mock_inner()
+        client = AnthropicClient(api_key="test")
+        client._client = mock_inner
+
+        with caplog.at_level(logging.WARNING, logger="accrue.steps.providers.anthropic"):
+            for _ in range(3):
+                await client.complete(
+                    messages=[{"role": "user", "content": "hi"}],
+                    model="claude-sonnet-5",
+                    temperature=0.2,
+                    max_tokens=1000,
+                )
+
+        warnings = [r for r in caplog.records if "does not accept an explicit" in r.message]
+        assert len(warnings) == 1
+        assert "claude-sonnet-5" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_warn_once_is_per_client_instance(self, caplog):
+        """Mirrors the grounding-schema warning's scope: once per pipeline run."""
+        TestAnthropicClient._install_mock_anthropic()
+        from accrue.steps.providers.anthropic import AnthropicClient
+
+        for _ in range(2):
+            caplog.clear()
+            client = AnthropicClient(api_key="test")
+            client._client = self._mock_inner()
+            with caplog.at_level(logging.WARNING, logger="accrue.steps.providers.anthropic"):
+                await client.complete(
+                    messages=[{"role": "user", "content": "hi"}],
+                    model="claude-sonnet-5",
+                    temperature=0.2,
+                    max_tokens=1000,
+                )
+            assert "does not accept an explicit temperature" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_dropping_the_models_own_default(self, caplog):
+        """Dropping 1.0 changes nothing — the API accepts it because it is the default."""
+        TestAnthropicClient._install_mock_anthropic()
+        from accrue.steps.providers.anthropic import AnthropicClient
+
+        client = AnthropicClient(api_key="test")
+        client._client = self._mock_inner()
+        with caplog.at_level(logging.WARNING, logger="accrue.steps.providers.anthropic"):
+            await client.complete(
+                messages=[{"role": "user", "content": "hi"}],
+                model="claude-sonnet-5",
+                temperature=1.0,
+                max_tokens=1000,
+            )
+
+        assert "does not accept an explicit temperature" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_no_warning_for_a_supported_model(self, caplog):
+        TestAnthropicClient._install_mock_anthropic()
+        from accrue.steps.providers.anthropic import AnthropicClient
+
+        client = AnthropicClient(api_key="test")
+        client._client = self._mock_inner()
+        with caplog.at_level(logging.WARNING, logger="accrue.steps.providers.anthropic"):
+            await client.complete(
+                messages=[{"role": "user", "content": "hi"}],
+                model="claude-sonnet-4-5-20250929",
+                temperature=0.2,
+                max_tokens=1000,
+            )
+
+        assert "does not accept an explicit temperature" not in caplog.text
+
+    @staticmethod
+    async def _complete_raising(model, message):
+        """Run ``complete()`` against a client whose SDK call raises *message*.
+
+        Installs a dedicated mock ``anthropic`` module so the ``APIError`` class
+        the adapter imports is the one raised here — ``_install_mock_anthropic``
+        uses ``setdefault``, so whichever module landed in ``sys.modules`` first
+        wins and may not carry real exception classes.
+        """
+        import sys
+
+        mock_mod = MagicMock()
+        mock_mod.APIError = type("APIError", (Exception,), {})
+        mock_mod.APITimeoutError = type("APITimeoutError", (Exception,), {})
+        mock_mod.RateLimitError = type("RateLimitError", (Exception,), {})
+        mock_mod.AsyncAnthropic = MagicMock()
+
+        with patch.dict(sys.modules, {"anthropic": mock_mod}):
+            from accrue.steps.providers.anthropic import AnthropicClient
+
+            mock_inner = MagicMock()
+            mock_inner.messages.create = AsyncMock(side_effect=mock_mod.APIError(message))
+            client = AnthropicClient(api_key="test")
+            client._client = mock_inner
+
+            await client.complete(
+                messages=[{"role": "user", "content": "hi"}],
+                model=model,
+                temperature=0.2,
+                max_tokens=1000,
+            )
+
+    @pytest.mark.asyncio
+    async def test_temperature_400_gets_an_actionable_hint(self):
+        """Models newer than the predicate knows about fail with accrue's guidance."""
+        with pytest.raises(LLMAPIError) as exc_info:
+            await self._complete_raising(
+                "claude-sonnet-9", "`temperature` is deprecated for this model."
+            )
+
+        assert "rejects an explicit temperature" in str(exc_info.value)
+        assert "claude-sonnet-9" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_unrelated_400_gets_no_temperature_hint(self):
+        with pytest.raises(LLMAPIError) as exc_info:
+            await self._complete_raising("claude-sonnet-4-5", "credit balance too low")
+
+        assert "rejects an explicit temperature" not in str(exc_info.value)
+        assert "credit balance too low" in str(exc_info.value)
+
+
 # -- GoogleClient -----------------------------------------------------------
 
 


### PR DESCRIPTION
Closes #109

## The failure

The Anthropic adapter sent `temperature` unconditionally, and no code path could reach the API
without one. `EnrichmentConfig.temperature` defaults to `0.2`, and `llm.py` substitutes a literal
`0.2` when nothing is set, so `None` never survived to the adapter.

The Claude 5 family removed the sampling parameters. An explicit value other than the model's own
default returns:

```
BadRequestError: 400 - `temperature` is deprecated for this model.
```

So **every row of every pipeline against `claude-sonnet-5` failed**, with no way to fix it from the
caller's side short of monkeypatching `AsyncMessages.create`. The failure was total rather than
degraded, and the message named a model capability, so it read like an API problem rather than an
accrue one.

## The fix

`accrue/steps/providers/anthropic.py` only sends `temperature` when the target model accepts one —
on the realtime path and the batch path alike:

```python
if temperature is not None and _supports_temperature(model):
    kwargs["temperature"] = temperature
else:
    self._warn_temperature_dropped(model, temperature)
```

Omitting the parameter is always accepted, and the model then samples at its default of `1.0` —
the value the issue confirmed the API accepts.

## Decisions

### 1. How the unsupported set is determined — **model-name predicate**

A module-level `_supports_temperature(model)` in the adapter, matching one regex:

```python
_NO_EXPLICIT_TEMPERATURE = re.compile(r"claude-(?:[a-z]+-5|opus-4-[78])(?!\d)")
```

**Rejected: retry-once-with-temperature-stripped.** It burns a real API call per row (or per batch)
before doing anything useful, converts a deterministic configuration problem into a runtime one
that costs money to discover, and makes correctness depend on parsing an error string Anthropic is
free to reword. The predicate is deterministic, free, and unit-testable with no network.

The predicate's real cost is maintenance as models ship. Two things pay it down:

- **Family-prefix matching, not an exhaustive literal list**, so unreleased Claude 5 variants,
  dated snapshots, and vendor-prefixed ids (`anthropic.claude-sonnet-5`,
  `us.anthropic.claude-sonnet-5-v1:0`) are covered without a code change.
- **A model family the predicate has not learned yet now fails loudly and self-explains.**
  Temperature-related API errors are suffixed with a hint naming accrue's knob and asking for a
  report, instead of surfacing the bare SDK message. The issue calls this out directly as part of
  the impact, and it is what makes "predicate over retry" safe: the gap is visible, not silent.

**Not accidentally matching Claude 3/4.** The first branch requires an *alphabetic* tier segment
between `claude-` and the major version, so ids that merely contain a `5` keep sending temperature.
Pinned by an 11-model negative parametrization: `claude-3-5-sonnet-20241022` (digit after
`claude-`), `claude-sonnet-4-5` / `claude-haiku-4-5` / `claude-opus-4-5-20251101` (major version 4),
plus `claude-opus-4-6`, `claude-sonnet-4-6`, `claude-3-opus-20240229`, and others.

**Deliberately beyond the issue's literal scope:** `claude-opus-4-7` and `claude-opus-4-8` also
removed the sampling parameters and produce the identical 400. That is one alternation branch and
the same one-line fix, so leaving a known-broken model out would be arbitrary. Flagging it
explicitly since the issue only names Claude 5.

**What is not covered:** a hypothetical future `claude-sonnet-6`. The predicate matches documented
behaviour rather than predicting it — guessing forward risks silently discarding temperature for a
model that supports it, which is a worse failure than a loud 400. When such a family ships, the fix
is one alternation and the hint above makes it self-reporting.

### 2. Warning on a dropped value — **yes, warn-once, gated on it mattering**

The adapter *cannot* distinguish "the user set 0.2" from "`EnrichmentConfig.temperature` defaulted
to 0.2" — by the time it sees a float, that information is gone. Threading an "explicit" flag down
would change the `LLMClient` protocol for every provider, including the custom adapters documented
in `docs/guides/providers.md`. Too much blast radius for a warning.

So the trigger is whether dropping it *changes behaviour*, which turns out to be the more useful
question: these models sample at `1.0` when the parameter is omitted, so dropping `1.0` is
semantically a no-op and stays silent, while dropping `0.2` really does change sampling away from
what the config asked for and warrants a warning.

Warn-once per client instance, using a `_warned_temperature_dropped` flag mirroring the existing
`_warned_grounding_schema` rather than a new pattern — same scope (once per pipeline run, not per
row), tested for both once-per-run and fires-again-on-a-new-client.

### 3. Should `temperature=None` survive `llm.py` — **not in this PR**

The adapter signature widens to `float | None` and skips sending on `None`, so "do not send" is
expressible at the provider boundary. `llm.py` resolution is unchanged.

`LLMStep(temperature=None)` is the *default argument* — it currently means "not specified", which
is how the overwhelming majority of callers hit it. Redefining `None` as "do not send" would
silently change behaviour for everyone who simply never passed the argument. Expressing "not
specified" and "explicitly nothing" as distinct states needs a sentinel or `model_fields_set`
plumbing through `llm.py`, `config.py` validation, `pipeline.py`'s `BatchRequest` construction, the
cache key, and the docs — a config-system change, not a bug fix. It is also unnecessary for the
reported failure: after this PR, Claude 5 models simply work.

## Out of scope (deliberately)

- No change to `EnrichmentConfig`, `llm.py`, or the `LLMClient` protocol.
- No change to `BatchRequest.temperature`'s declared `float` type — widening it would leak `None`
  into the OpenAI batch path, which sends it unconditionally.
- Google and OpenAI adapters untouched; the constraint is Anthropic's.
- `provider_kwargs={"temperature": ...}` still overrides the omission — the documented escape hatch
  is preserved and pinned by a test.

## Tests

47 new tests (`tests/test_providers.py`, `tests/test_batch_anthropic.py`) in the existing
`SimpleNamespace` / `AsyncMock` style, no network:

- 22 predicate cases: 11 models that must not receive temperature (Claude 5 family, dated snapshot,
  point release, Bedrock prefix, mixed case, Opus 4.7/4.8) and 11 that must still receive it.
- Realtime: Claude 5 gets no `temperature` in the call kwargs; Claude 4 still does; `None` is never
  sent; `provider_kwargs` still overrides.
- Batch: same assertions on the submitted `params`, including a mixed-model batch proving the rule
  is per-request, not per-batch.
- Warning: fires once for a dropped `0.2`, again on a fresh client, silent for `1.0`, silent for a
  supported model, once per batch submission.
- Error hint: present for a temperature 400 on an unknown model, absent for an unrelated 400,
  absent when accrue sent no temperature at all, and naming the right model in a mixed batch.
- `provider_kwargs` override does not trigger the "value was dropped" warning.

## Gate

Verified with the versions CI resolves, not the local `.venv` (which pins ruff 0.15.12 and
disagrees with CI's 0.16.3):

```
$ uv tool run --from "ruff==0.16.3" ruff check .
All checks passed!

$ uv tool run --from "ruff==0.16.3" ruff format --check .
79 files already formatted

$ python -m pytest -q
790 passed, 1 skipped, 1 warning in 16.89s
```

Baseline re-measured on this branch's merge base (`git stash`, same command): **743 passed,
1 skipped**. So +47 tests, zero regressions.

Rebased onto current `main` (`59e0701`, #115) after review, since that commit also touches
`anthropic.py`, `providers.md`, and `test_providers.py`. Gate re-run clean on the rebased tree;
the PR is `CLEAN` / `MERGEABLE` rather than `BEHIND`. (Main has moved twice during this PR:
`75d51a3` -> `dd6b6da` -> `59e0701`.)

## Reviewer notes

- The verification value of the predicate is entirely in the *negative* parametrization; if you
  read one thing, read `TEMPERATURE_MODELS` in `tests/test_providers.py`.
- `_supports_temperature` lowercases before matching, so mixed-case ids are handled.
- The two temperature-hint tests install their own mock `anthropic` module via `patch.dict` rather
  than the shared `_install_mock_anthropic()` helper, which uses `sys.modules.setdefault` — an
  earlier test in the file installs a bare `MagicMock` with no real exception classes, so
  whichever module lands first wins for the session. Noted in a docstring at the call site.
