### PR TITLE
docs: correct stale repo metadata and document four undocumented exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Agentic SDLC scaffolding: GitHub Actions for `@claude` mention, PR review, weekly maintenance, and dogfooded issue triage. Repo-scoped slash commands under `.claude/commands/`. Local `PostToolUse` hook for ruff-on-edit. See `AGENTS.md`.
+- **`accrue.compare(result_a, result_b)`** — diff two pipeline runs. Aligns rows explicitly (positionally for default `RangeIndex`, by label for real indexes, with a warning and positional fallback on non-unique or mixed-kind indexes) rather than via a blind index intersection that silently yields garbage. `changed_rows(field=None)` returns a before/after frame of differing rows; `distribution_shift()` reports per-field churn — frequency tables for enums, mean/std for numbers, differs-count plus an approximate token delta otherwise. Cell equality is null-safe and container-safe. (#36)
+- **`Pipeline.plan(data, sample_size=3)`** — dry-run preview returning a `PipelinePlan`. Introspects each step's resolved system prompt and JSON schema, runs a capped real sample, and extrapolates measured token usage to the full dataset; `summary()` renders a terraform-plan-style preview. Cost is extrapolated only over rows that actually called the API, so cached sample rows don't deflate the estimate. Also adds `run(..., confirm=True)` to print the plan and prompt before the full run. See `docs/guides/plan-mode.md`. (#12)
+- **`output_file` / `PipelineResult.save(path)`** — write enriched data to disk, inferring format from the extension (`.csv` / `.json` / `.parquet`). When `output_file` is passed to `run()` / `run_async()`, the save happens *before* the call returns, so an error in the caller's own post-processing can no longer discard a completed, already-paid-for run. (#10)
 - **`PipelineResult.report(format, path, disable)`** — heuristic-driven Markdown/HTML run summary. Headlines suspicious patterns (enum collapse, numeric clipping, length anomalies, retry storms, refusal phrases, cache thrash, cost outliers) with a probable cause and a suggested action; backed by a per-step stats table. Pass `disable=[...]` to mute individual heuristic codes. See `docs/guides/report.md`. (#32)
 - `PipelineResult` now exposes `pipeline_elapsed_seconds`, `step_elapsed_seconds`, and `field_specs`, populated by `Pipeline.run_async()` so reporters and custom heuristics can introspect.
 
 ### Changed
-- **`EnrichmentConfig.enable_caching` now defaults to `True`** (was `False`). Re-runs of unchanged inputs no longer re-pay the API cost. Opt out with `EnrichmentConfig(enable_caching=False)` for one-off runs.
-- **`LLMStep` auto-detects provider from model name.** `claude-*` → `AnthropicClient`, `gemini-*` → `GoogleClient`, anything else (or any model with `base_url` set) → `OpenAIClient`. Previously every Claude/Gemini user had to pass `client=AnthropicClient()` or `client=GoogleClient()` explicitly. Explicit `client=` still wins. (#23)
 - **`Pipeline.execute()` returns a 4-tuple** `(accumulated, errors, cost, step_elapsed_seconds)` instead of a 3-tuple. Internal API (not exported in `accrue.__all__`); callers using `Pipeline.run()` / `run_async()` are unaffected.
 
 ### Fixed
+- **The Claude 5 family works again.** The Anthropic adapter always sent `temperature` and no code path could omit it — `llm.py` substituted a literal `0.2` when none was given, and `EnrichmentConfig.temperature` itself defaults to `0.2`, so `None` never reached the adapter. Claude 5 models reject an explicit temperature, so every call to `claude-sonnet-5`, `claude-opus-5`, or `claude-fable-5` returned a 400 with an error that named the model rather than accrue. The parameter is now omitted for models that reject it (matched by family, so unreleased Claude 5 variants and `anthropic.` / `us.anthropic.` prefixes are covered), on both the realtime and batch paths. Dropping an explicit value warns once, and temperature-related API errors carry an actionable hint. Also covers `claude-opus-4-7` and `claude-opus-4-8`, which removed the sampling parameters too. (#109)
 - **Prompt caching now actually hits.** The row's own data was built into the same system message the Anthropic adapter marks `cache_control: {"type": "ephemeral"}`, so the cached prefix changed on every row: every call wrote a fresh entry at 1.25x input and none was ever read at 0.1x — a standing ~25% surcharge on every input token for a feature that never fired. The prompt builder now returns the prompt already split (`build_prompt() -> PromptParts(system, user)`): instructions and `<field_specifications>` stay in the cacheable system block, `<row_data>` and `<prior_results>` move to the user message. The reminder stays last in the user message, preserving the sandwich pattern. (#107)
 - Anthropic: `cache_creation_input_tokens` and `cache_read_input_tokens` are now carried through `UsageInfo`, `StepUsage`, and `CostSummary`, and counted in `total_tokens`. Cost reports previously omitted prompt-cache tokens, under-reporting the bill by up to ~63x on cached workloads. The pipeline summary now shows cache write/read totals so silent prompt-cache failures are visible. (#108)
+
+### Internal
+- CI: Markdown is excluded from ruff (`extend-exclude = ["*.md"]`). The dev extras are unbounded, so CI resolved ruff 0.16, which began formatting Python code blocks inside Markdown and failed `ruff format --check` on 24 untouched files across `README.md`, `docs/`, and `.claude/skills/`. The network-blocking test fixture also now patches `httpx2` as well as `httpx`, since `openai>=3` moved to the `httpx2` package and CI installs only `.[dev]`, which pulls neither on its own. `main` had been red since both landed. (#113)
+
+## [1.3.0] - 2026-05-19
+
+### Added
+- Agentic SDLC scaffolding: GitHub Actions for `@claude` mention, PR review, weekly maintenance, and dogfooded issue triage. Repo-scoped slash commands under `.claude/commands/`. Local `PostToolUse` hook for ruff-on-edit. See `AGENTS.md`.
+
+### Changed
+- **`EnrichmentConfig.enable_caching` now defaults to `True`** (was `False`). Re-runs of unchanged inputs no longer re-pay the API cost. Opt out with `EnrichmentConfig(enable_caching=False)` for one-off runs.
+- **`LLMStep` auto-detects provider from model name.** `claude-*` → `AnthropicClient`, `gemini-*` → `GoogleClient`, anything else (or any model with `base_url` set) → `OpenAIClient`. Previously every Claude/Gemini user had to pass `client=AnthropicClient()` or `client=GoogleClient()` explicitly. Explicit `client=` still wins. (#23)
+
+### Fixed
 - `LLMStep.parse_response` now strips markdown code fences before `json.loads`. Fixes parse failures with Claude Haiku + grounding tools, where the structured-output constraint is disabled and the model wraps JSON in ` ``` ` fences. (#7)
 - `accrue/__init__.py` `__version__` was out of sync with `pyproject.toml`.
 - Google provider: Option-B rate-limit fallback now uses a word-boundary regex (`\brate[\s_-]?limit\b`) instead of bare `"rate" in exc_str`, preventing false positives on words like "iterate" or "accelerator". (#80)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,11 @@
 # Accrue
 
-Composable enrichment pipeline engine. The gap between Instructor (single LLM call) and Clay (full SaaS platform). v1.0.0, Python 3.10+.
+Composable enrichment pipeline engine. The gap between Instructor (single LLM call) and Clay (full SaaS platform). v1.3.0, Python 3.10+.
 
 ## Commands
 
 ```bash
-pytest                          # Run all tests (483)
+pytest                          # Run all tests (791)
 pytest tests/unit/              # Unit tests only
 pytest -x -q                    # Fast fail
 python -m build                 # Build package
@@ -47,7 +47,15 @@ Types: `feat`, `fix`, `docs`, `refactor`, `test`
 
 **Always include labels.** Format: `[Type]: [Component] Description`
 
-Labels: `type:{epic,story,task,bug,spike}`, `priority:{critical,high,medium,low}`, `component:{core,steps,pipeline,data,testing,docs,infra}`
+Labels that actually exist on the repo (`gh label list` is the source of truth):
+
+- Type: `bug`, `enhancement`, `documentation`, `question`, `duplicate`, `invalid`, `wontfix`
+- Priority: `priority:{high,medium,low}`
+- Other: `backlog` (not on the near-term roadmap), `meta` (dev tooling, not user-facing),
+  `good first issue`, `help wanted`, `needs info`, `release`
+
+There is no `type:*` or `component:*` namespace — `gh issue create --label type:task`
+fails. Create the label first if you want a new one.
 
 See `docs/guides/` for details.
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -137,6 +137,38 @@ config = EnrichmentConfig(
 
 When `auto_resume=True`, the pipeline detects an existing checkpoint on re-run and skips already-completed steps. Set `checkpoint_interval` to a positive integer to save partial progress within long-running steps.
 
+## Logging
+
+Accrue logs through the standard `logging` module and does not configure
+handlers on import, so by default you see whatever your application already set
+up. `setup_logging()` is a convenience for when you have not set anything up:
+
+```python
+from accrue import setup_logging
+
+setup_logging(level="DEBUG")                    # colored console output
+setup_logging(level="INFO", format_type="json")  # structured, one JSON object per line
+```
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `level` | `"INFO"` | `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL` |
+| `format_type` | `"console"` | `"console"` for colored human-readable output, `"json"` for structured logs |
+| `include_timestamp` | `True` | Include timestamps in console format (ignored for `json`) |
+
+It configures the **root** logger and replaces any handlers already attached, so
+call it once at startup and don't call it from library code. If your application
+already configures logging, skip it entirely — accrue's loggers propagate
+normally.
+
+Most of accrue's own diagnostics are `WARNING` and above (retry exhaustion,
+rate-limit fallbacks, batch-cancel failures, dropped `temperature`, checkpoint
+mismatches), so `INFO` is a reasonable default. `DEBUG` currently adds only
+`LLMStep._apply_defaults` decisions — when a value matched a refusal pattern and
+was replaced with the field default, and when it was kept because it is a
+declared enum member. For run-level diagnosis reach for `result.report()` and
+`result.summary()` rather than the log stream.
+
 ## Validation
 
 `EnrichmentConfig` validates all fields on construction:

--- a/docs/guides/function-steps.md
+++ b/docs/guides/function-steps.md
@@ -150,6 +150,46 @@ FunctionStep(
 )
 ```
 
+## Writing a custom Step
+
+`FunctionStep` covers most non-LLM logic. When you need more — your own caching
+behaviour, your own usage accounting, or state held across rows — implement the
+`Step` protocol directly. A step is any object with a `name`, a `fields` list,
+`depends_on`, and an async `run(ctx) -> StepResult`:
+
+```python
+from accrue import Pipeline, Step, StepContext, StepResult
+
+class GeocodeStep:
+    """Resolve an address to coordinates via an external service."""
+
+    name = "geocode"
+    fields = ["lat", "lon"]
+    depends_on: list[str] = []
+
+    async def run(self, ctx: StepContext) -> StepResult:
+        lat, lon = await lookup(ctx.row["address"])
+        return StepResult(values={"lat": lat, "lon": lon})
+
+assert isinstance(GeocodeStep(), Step)  # runtime_checkable
+pipeline = Pipeline([GeocodeStep()])
+```
+
+`Step` is a `runtime_checkable` `Protocol`, so there is no base class to inherit
+— satisfying the shape is enough.
+
+`StepResult` is what every step hands back:
+
+| Attribute | Meaning |
+|---|---|
+| `values` | `dict[str, Any]` — field name → produced value. Filtered to the step's declared `fields`, same as `FunctionStep`. |
+| `usage` | Optional `UsageInfo`. LLM steps populate it; leave it `None` unless your step calls a model and you want its tokens in `result.cost`. |
+| `metadata` | Arbitrary dict for logging and debugging. Not written to the output frame. |
+
+Steps must be pure with respect to their inputs — read from `ctx`, return a
+`StepResult`, don't mutate `ctx.row`. See the [API reference](../reference/api.md)
+for the full `Step`, `StepContext`, and `StepResult` definitions.
+
 ## Gotchas
 
 - FunctionStep only accepts `fields` as `list[str]`. Dict field specs (with prompts, types, etc.) are an LLMStep feature.

--- a/docs/guides/plan-mode.md
+++ b/docs/guides/plan-mode.md
@@ -30,6 +30,35 @@ or assert on it in a test). The structured fields are also available directly on
 the `PipelinePlan`: `steps`, `sample_rows`, `sample_outputs`, `sample_errors`,
 `total_rows`, `sample_size`, `sample_cost`, and `estimated_cost`.
 
+### Inspecting individual steps
+
+`plan.steps` is a list of `StepPlan` objects — one per step, in execution order —
+so you can assert on a single step instead of string-matching `summary()`:
+
+```python
+from accrue import StepPlan  # exported at the top level
+
+plan = pipeline.plan(df)
+
+for step in plan.steps:
+    print(step.name, step.kind, step.depends_on)
+
+# Catch a prompt regression before paying for a full run
+enrich = next(s for s in plan.steps if s.name == "enrich")
+assert "investment thesis" in enrich.system_prompt
+```
+
+| Attribute | Meaning |
+|---|---|
+| `name` | Step name |
+| `kind` | `"llm"`, `"function"`, or `"other"` (a custom `Step`) |
+| `depends_on` | Names of upstream steps this one consumes |
+| `model` | Model identifier (LLM steps only) |
+| `system_prompt` | The resolved system prompt — the static, cacheable half (LLM steps only) |
+| `response_format` | The `response_format` the step will send: a JSON schema dict, or `{"type": "json_object"}` for freeform (LLM steps only) |
+
+The non-LLM attributes are `None` on function and custom steps.
+
 ## Cost estimation
 
 The estimate extrapolates the sample's *measured* tokens to the full dataset.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,10 @@ build-backend = "hatchling.build"
 
 [project]
 name = "accrue"
+# Keep in sync with __version__ in accrue/__init__.py. This static value is the
+# one that ships, and .github/workflows/publish.yml reads it via
+# tomllib -> ["project"]["version"] to verify the git tag matches, so it cannot
+# be replaced with `dynamic = ["version"]` without updating that check too.
 version = "1.3.0"
 authors = [
   { name="Matthew House", email="matt.house.e@gmail.com" },
@@ -55,9 +59,6 @@ all = [
 "Bug Reports" = "https://github.com/matt-house-e/accrue/issues"
 "Source" = "https://github.com/matt-house-e/accrue"
 "Documentation" = "https://github.com/matt-house-e/accrue#readme"
-
-[tool.hatch.version]
-path = "accrue/__init__.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["accrue"]


### PR DESCRIPTION
## Summary

Clears the housekeeping the weekly maintenance sweep has been re-reporting identically since June (#97–#106, #112), plus four public exports that were documented nowhere.

## CLAUDE.md

| Was | Now |
|---|---|
| `v1.0.0` in the header | `v1.3.0` |
| `# Run all tests (483)` | `# Run all tests (791)` |
| Labels `type:{...}` / `component:{...}` | The labels that actually exist |

The label taxonomy is worth calling out: `type:*` and `component:*` **do not exist on this repo**, so following CLAUDE.md's instruction produces `could not add label: 'type:task' not found`. I hit this filing #116. Replaced with what `gh label list` returns.

## CHANGELOG.md

- **Added a `[1.3.0] - 2026-05-19` section.** 1.3.0 was tagged at `0d95436` and published to PyPI, but its release notes were still under `[Unreleased]`. The split isn't guessed — `git show v1.3.0:CHANGELOG.md` shows exactly what was under Unreleased at the tag, and that is what moved.
- **Added three features that had no changelog entry at all**: `compare()` (#36), `Pipeline.plan()` (#12), and `output_file` / `PipelineResult.save()` (#10). Descriptions written from the merge commits.
- Added entries for #109 and #113.

## pyproject.toml

Removed the dead `[tool.hatch.version]` block. `dynamic = ["version"]` was never declared, so hatchling ignored it and shipped the static `version` — it read as the source of truth while doing nothing.

**I tried the other fix first and backed it out.** Converting to `dynamic = ["version"]` is the better end state, and the wheel builds fine — but `.github/workflows/publish.yml:25` does:

```python
tomllib.load(open('pyproject.toml','rb'))['project']['version']
```

With `dynamic` and no static key that raises `KeyError`, so **the next release would have failed**. Doing it properly means changing the publish workflow and the release skill together, which is its own PR and can't be smoke-tested from a workflow-modifying PR. Left a comment recording the coupling instead.

## docs/ — four undocumented exports

All four are in `accrue.__all__`:

- **`StepPlan`** — appeared in no guide, README, or reference page. Now in `plan-mode.md` with its attribute table and a worked example (assert on a step's resolved prompt to catch a regression before paying for a full run).
- **`setup_logging`** — same, nowhere. Now in `configuration.md`. Documents that it reconfigures the **root** logger and clears existing handlers, and — after checking rather than assuming — that `DEBUG` only adds `_apply_defaults` refusal-pattern decisions; the real diagnostics are at `WARNING` and above.
- **`StepResult`** — existed only in `docs/reference/api.md`, and **no guide covered custom steps at all**. Added a "Writing a custom Step" section to `function-steps.md`. The example was executed against this tree, not just written — it satisfies `isinstance(x, Step)` and runs through a real pipeline.
- **`Enricher`** — deliberately left as reference-only. It's the internal runner for power users; a guide section would overstate it. Flagging so the sweep's finding is answered rather than silently ignored.

## Testing

```
uv tool run --from "ruff==0.16.3" ruff check .          → All checks passed!
uv tool run --from "ruff==0.16.3" ruff format --check . → 79 files already formatted
python -m pytest -q                                     → 790 passed, 1 skipped
```

Also verified, since this PR touches packaging:

- `pyproject-build --wheel` → `accrue-1.3.0-py3-none-any.whl`
- `tomllib.load(...)["project"]["version"]` → `1.3.0` (publish.yml's check still resolves)
- The custom-Step doc example runs end-to-end and returns enriched rows

No source changes — `accrue/` is untouched.

## Checklist

- [x] Tests pass
- [x] Linting/formatting passes
- [x] Self-reviewed
- [x] Documentation updated
