### PR TITLE
docs: require a review pass before merging fork PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,18 @@ Types: `feat`, `fix`, `docs`, `refactor`, `test`
 - Source code (`accrue/`), Tests (`tests/`), Examples (`examples/`), Docs (`.md`)
 - Never: `data/`, `.env`, `.vscode/`, `.idea/`, `.notes/`
 
+### Merging PRs
+
+- **A PR from a fork by a non-collaborator must get a review pass before merge.**
+  Nothing reviews PRs automatically — the auto-review workflow was dropped in #136,
+  so reviews run ad hoc. Either review the diff locally with Claude Code, or comment
+  `@claude review` on the PR: that path is `claude.yml`, which fires on
+  `issue_comment` in base-repo context and so has repository secrets even for fork
+  PRs (a `pull_request`-triggered job would not). Read the result, then merge.
+- Green CI is not a review. `main` requires `test (3.10-3.13)`, which proves the
+  tests pass — not that the diff does what it says.
+- Never merge with `--admin`. If branch protection blocks a merge, fix the cause.
+
 ## GitHub Issues
 
 **Always include labels.** Format: `[Type]: [Component] Description`


### PR DESCRIPTION
## Why

#110 was a fork PR from a first-time external contributor. It merged to `main` with
**zero review comments and no review workflow run**. The diff turned out to be clean —
a legitimate Anthropic cache-token accounting fix — but nothing in the process would
have caught it if it hadn't been.

The root cause is a trigger gap, not a missing capability:

- `claude-review.yml` fires on `pull_request`. For **fork** PRs GitHub runs that event
  without repository secrets, so the review job cannot authenticate and never fires.
- `claude.yml` fires on `issue_comment`, which runs in **base-repo** context *with*
  secrets. `@claude review` therefore works fine on forks — nobody invoked it.

So the review capability was there the whole time; the automatic path just silently
doesn't cover the exact case that needs it most.

## What changed

One subsection in `CLAUDE.md` under Git Workflow — no workflow or branch-protection
changes:

- A fork PR from a non-collaborator must get a review pass before merge, via
  `@claude review`.
- Green CI is not a review. `main` requires `test (3.10-3.13)`, which proves the tests
  pass, not that the diff does what it says.
- Never merge with `--admin`. If branch protection blocks a merge, fix the cause.

## Deliberately not done

- **Requiring an approving review on `main`** — self-blocking on a solo-maintainer repo.
  GitHub won't let you approve your own PR, so it would make every self-merge require an
  admin bypass, which trains the habit this PR is trying to prevent.
- **Switching `claude-review.yml` to `pull_request_target`** — that would run with repo
  secrets while checking out untrusted fork code. Textbook exfiltration vector.

## Verification

`805 passed, 1 skipped`. Docs-only change; ruff excludes Markdown (#113).

Note: line 8 still reads `Run all tests (791)` — actual count is now 805. Left alone as
out of scope here; #119 was already opened to correct that number.
