### PR TITLE
docs: stop hand-maintaining test counts in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@ Composable enrichment pipeline engine. The gap between Instructor (single LLM ca
 ## Commands
 
 ```bash
-pytest                          # Run all tests (806) — tests/integration excluded via norecursedirs
-pytest tests/integration/       # Integration tests (11), opt-in only
+pytest                          # Run all tests — tests/integration excluded via norecursedirs
+pytest tests/integration/       # Integration tests, opt-in only
 pytest -x -q                    # Fast fail
 python -m build                 # Build package
 pip install -e ".[dev]"         # Dev install


### PR DESCRIPTION
Follow-up to #119.

## Why

The test count in CLAUDE.md went stale **four times in one day**:

| Value | Made stale by |
|---|---|
| 483 | (long stale) |
| 791 | #117 corrected it |
| 803 | #118 added 12 tests |
| 806 | #120 added 3 tests |

Every commit that adds a test invalidates it, nothing enforces it, and #119 had to be amended mid-review because main moved underneath it. A wrong number in the first file an agent reads is worse than no number — it produces confident "791 tests" claims that were true last week.

It also earns nothing: `pytest` prints the true count directly above its own summary line.

## What changed

```diff
-pytest                          # Run all tests (806) — tests/integration excluded via norecursedirs
-pytest tests/integration/       # Integration tests (11), opt-in only
+pytest                          # Run all tests — tests/integration excluded via norecursedirs
+pytest tests/integration/       # Integration tests, opt-in only
```

Both counts dropped. The parts that actually carry information — that `norecursedirs` excludes integration from the default run, and that the integration suite is opt-in — stay. Those are facts about configuration, not a number that decays.

The alternative was asserting the count in `tests/test_repo_metadata.py` alongside the version/CHANGELOG checks #120 added. Rejected: that turns every test-adding PR into a two-file change to satisfy a number nobody reads.

Docs-only; no source or test files touched.