### PR TITLE
test: pin the public API surface with a snapshot contract (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Public API snapshot test.** `tests/public_api_snapshot.json` pins every name exported from `accrue`, `accrue.providers`, `accrue.data` and `accrue.core.exceptions` — kind, signature, accrue-defined members, Pydantic model fields, Protocol methods and exception base chains. `tests/test_public_api.py` rebuilds that surface at test time and fails on any divergence, printing the exact delta grouped into REMOVED / CHANGED / ADDED plus the regeneration steps. Additions fail too, deliberately: the value of the gate is that every surface change lands in the PR diff as readable JSON. Scope reaches past `accrue.__all__` because `docs/` and `examples/` import `AnthropicClient`, `load_fields` and `ConfigurationError` directly. Regenerate with `python -m tests.test_public_api --update`. No new dependencies — stdlib `inspect` only. (#121)
+
 ## [1.4.0] - 2026-09-01
 
 The first release that actually contains Accrue Watch support. The README has advertised `run_log=True` and `accrue watch` for months, and 1.3.0 shipped neither — 1.4.0 closes that gap. Headline contents: the **run-log contract v1**, an append-only JSONL stream of a run that a dashboard can follow live; the **`accrue` console script** and its **`watch`** subcommand; **`Pipeline.retry_failed()`**, which heals only the cells a previous run left failing; **run-log v0.2**'s capture tiers, per-attempt events and prompt sidecar, so a retried cell can be inspected attempt by attempt; and the **run manifest**, which gives that dashboard the run's *definition* — steps, models, field schema, config, system prompts — and not just its results.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ Composable enrichment pipeline engine. The gap between Instructor (single LLM ca
 pytest                          # Run all tests — tests/integration excluded via norecursedirs
 pytest tests/integration/       # Integration tests, opt-in only
 pytest -x -q                    # Fast fail
+python -m tests.test_public_api --update   # Regenerate the public API snapshot
 python -m build                 # Build package
 pip install -e ".[dev]"         # Dev install
 pip install -e ".[anthropic]"   # With Anthropic provider
@@ -21,6 +22,7 @@ pip install -e ".[google]"      # With Google provider
 - **Internal fields**: `__` prefix (e.g. `__web_context`) for inter-step data, filtered from output.
 - **Prompt split**: `build_prompt()` returns `PromptParts(system, user)`. Keep the `system` half row-independent — providers cache on an exact prefix match, so any per-row content in it turns caching into a 1.25x surcharge (#107).
 - **Minimal deps**: Base: `openai`, `pydantic`, `pandas`, `tqdm`, `python-dotenv`. Never add litellm/langfuse.
+- **Public API is under contract.** `tests/public_api_snapshot.json` pins every name exported from `accrue`, `accrue.providers`, `accrue.data` and `accrue.core.exceptions`. Any change to that surface — including a purely additive one — fails `tests/test_public_api.py`. That is deliberate: it puts the change in the PR diff as readable JSON. To change the API on purpose, run `python -m tests.test_public_api --update`, commit the regenerated snapshot in the same PR, and add a `CHANGELOG.md` entry under `[Unreleased]`. Never hand-edit the snapshot (#121).
 - See `docs/guides/` for architecture, providers, caching, grounding, run-log details.
 - **Run-log contract v1**: `run(..., run_log=True)` emits JSONL via `JsonlRunLogger` (a hooks consumer, `accrue/core/runlog.py`). Additive changes only within v1 — never rename/remove fields without bumping `SCHEMA_VERSION`; golden fixture `tests/fixtures/run_small.jsonl` is what accrue-ui tests against. `pipeline_start` carries a nested `manifest` object (the run's definition: steps+types+models, field schema, config — built by `accrue/core/manifest.py`, #138) that must stay row-independent and deterministic (no timestamps/rng); regenerate the fixture with `python tests/fixtures/generate_run_fixture.py` and keep `test_regeneration_is_stable` green.
 

--- a/tests/public_api_snapshot.json
+++ b/tests/public_api_snapshot.json
@@ -1,0 +1,705 @@
+{
+  "accrue": {
+    "exports": [
+      "BatchCapableLLMClient",
+      "BatchRequest",
+      "BatchResult",
+      "ComparisonResult",
+      "CostSummary",
+      "Enricher",
+      "EnrichmentConfig",
+      "EnrichmentError",
+      "EnrichmentHooks",
+      "FieldSpec",
+      "FieldValidationError",
+      "FunctionStep",
+      "GroundingConfig",
+      "JsonlRunLogger",
+      "LLMStep",
+      "Pipeline",
+      "PipelineEndEvent",
+      "PipelineError",
+      "PipelinePlan",
+      "PipelineResult",
+      "PipelineStartEvent",
+      "RowAttemptEvent",
+      "RowCompleteEvent",
+      "RowError",
+      "Step",
+      "StepContext",
+      "StepEndEvent",
+      "StepError",
+      "StepPlan",
+      "StepResult",
+      "StepStartEvent",
+      "compare",
+      "is_batch_capable",
+      "read_prompt_ref",
+      "setup_logging",
+      "web_search"
+    ],
+    "names": {
+      "BatchCapableLLMClient": {
+        "kind": "protocol",
+        "members": {
+          "cancel_batch": {
+            "kind": "method",
+            "signature": "(self, batch_id: str) -> None"
+          },
+          "complete": {
+            "kind": "method",
+            "signature": "(self, messages: list[dict[str, Any]], model: str, temperature: float, max_tokens: int, response_format: dict[str, Any] | None = None, tools: list[dict[str, Any]] | None = None, provider_kwargs: dict[str, Any] | None = None) -> LLMResponse"
+          },
+          "poll_batch": {
+            "kind": "method",
+            "signature": "(self, batch_id: str, poll_interval: float = 60.0, timeout: float = 86400.0) -> BatchResult"
+          },
+          "submit_batch": {
+            "kind": "method",
+            "signature": "(self, requests: list[BatchRequest], metadata: dict[str, str] | None = None) -> str"
+          }
+        }
+      },
+      "BatchRequest": {
+        "kind": "dataclass",
+        "members": {},
+        "signature": "(custom_id: str, messages: list[dict[str, Any]], model: str, temperature: float, max_tokens: int, response_format: dict[str, Any] | None = None, tools: list[dict[str, Any]] | None = None, provider_kwargs: dict[str, Any] | None = None) -> None"
+      },
+      "BatchResult": {
+        "kind": "dataclass",
+        "members": {},
+        "signature": "(responses: dict[str, LLMResponse] = <factory>, failed_ids: list[str] = <factory>, batch_id: str = '', errors: dict[str, str] = <factory>) -> None"
+      },
+      "ComparisonResult": {
+        "kind": "dataclass",
+        "members": {
+          "changed_rows": {
+            "kind": "method",
+            "signature": "(self, field: str | None = None) -> pd.DataFrame"
+          },
+          "cost_delta": {
+            "kind": "method",
+            "signature": "(self) -> CostDelta"
+          },
+          "distribution_shift": {
+            "kind": "method",
+            "signature": "(self) -> dict[str, FieldChurn]"
+          },
+          "report": {
+            "kind": "method",
+            "signature": "(self, output_format: str = 'markdown', path: str | None = None) -> str"
+          },
+          "summary": {
+            "kind": "method",
+            "signature": "(self) -> str"
+          }
+        },
+        "signature": "(result_a: PipelineResult, result_b: PipelineResult, label_a: str, label_b: str, fields: list[str], field_specs: dict[str, dict[str, Any]], aligned_a: pd.DataFrame, aligned_b: pd.DataFrame, align_mode: \"Literal['positional', 'label']\", pos_a: list[int], pos_b: list[int]) -> None"
+      },
+      "CostSummary": {
+        "fields": {
+          "steps": {
+            "annotation": "dict[str, StepUsage]",
+            "default": "{}",
+            "required": false
+          },
+          "total_cache_read_tokens": {
+            "annotation": "<class 'int'>",
+            "default": "0",
+            "required": false
+          },
+          "total_cache_write_tokens": {
+            "annotation": "<class 'int'>",
+            "default": "0",
+            "required": false
+          },
+          "total_completion_tokens": {
+            "annotation": "<class 'int'>",
+            "default": "0",
+            "required": false
+          },
+          "total_prompt_tokens": {
+            "annotation": "<class 'int'>",
+            "default": "0",
+            "required": false
+          },
+          "total_tokens": {
+            "annotation": "<class 'int'>",
+            "default": "0",
+            "required": false
+          }
+        },
+        "kind": "pydantic_model",
+        "members": {},
+        "signature": "(*, total_prompt_tokens: int = 0, total_completion_tokens: int = 0, total_tokens: int = 0, total_cache_write_tokens: int = 0, total_cache_read_tokens: int = 0, steps: dict[str, StepUsage] = {}) -> None"
+      },
+      "Enricher": {
+        "kind": "class",
+        "members": {
+          "run": {
+            "kind": "method",
+            "signature": "(self, df: pd.DataFrame, overwrite_fields: bool | None = None, data_identifier: str | None = None) -> pd.DataFrame"
+          },
+          "run_async": {
+            "kind": "method",
+            "signature": "(self, df: pd.DataFrame, overwrite_fields: bool | None = None, data_identifier: str | None = None) -> pd.DataFrame"
+          }
+        },
+        "signature": "(pipeline: Pipeline, config: EnrichmentConfig | None = None, hooks: Any = None) -> None"
+      },
+      "EnrichmentConfig": {
+        "kind": "dataclass",
+        "members": {
+          "for_batch": {
+            "kind": "classmethod",
+            "signature": "(cls) -> \"'EnrichmentConfig'\""
+          },
+          "for_development": {
+            "kind": "classmethod",
+            "signature": "(cls) -> \"'EnrichmentConfig'\""
+          },
+          "for_production": {
+            "kind": "classmethod",
+            "signature": "(cls) -> \"'EnrichmentConfig'\""
+          },
+          "for_server": {
+            "kind": "classmethod",
+            "signature": "(cls) -> \"'EnrichmentConfig'\""
+          }
+        },
+        "signature": "(max_tokens: int = 4000, temperature: float = 0.2, max_workers: int = 10, overwrite_fields: bool = False, max_retries: int = 3, retry_base_delay: float = 1.0, on_error: str = 'continue', log_level: str = 'INFO', enable_progress_bar: bool = True, enable_checkpointing: bool = False, checkpoint_dir: str = <factory>, auto_resume: bool = True, enable_caching: bool = True, cache_ttl: int = 3600, cache_dir: str = <factory>, checkpoint_interval: int = 0, batch_poll_interval: float = 60.0, batch_timeout: float = 86400.0, batch_max_requests: int = 50000) -> None"
+      },
+      "EnrichmentError": {
+        "bases": [
+          "Exception",
+          "BaseException"
+        ],
+        "kind": "exception",
+        "members": {},
+        "signature": "(message: str, row_index: int | None = None, field: str | None = None)"
+      },
+      "EnrichmentHooks": {
+        "kind": "dataclass",
+        "members": {},
+        "signature": "(on_pipeline_start: Callable[[PipelineStartEvent], Any] | None = None, on_pipeline_end: Callable[[PipelineEndEvent], Any] | None = None, on_step_start: Callable[[StepStartEvent], Any] | None = None, on_step_end: Callable[[StepEndEvent], Any] | None = None, on_row_complete: Callable[[RowCompleteEvent], Any] | None = None, on_row_attempt: Callable[[RowAttemptEvent], Any] | None = None) -> None"
+      },
+      "FieldSpec": {
+        "fields": {
+          "bad_examples": {
+            "annotation": "list[str] | None",
+            "default": "None",
+            "required": false
+          },
+          "default": {
+            "annotation": "Any",
+            "default": "None",
+            "required": false
+          },
+          "enum": {
+            "annotation": "list[str] | None",
+            "default": "None",
+            "required": false
+          },
+          "examples": {
+            "annotation": "list[str] | None",
+            "default": "None",
+            "required": false
+          },
+          "format": {
+            "annotation": "str | None",
+            "default": "None",
+            "required": false
+          },
+          "prompt": {
+            "annotation": "<class 'str'>",
+            "default": null,
+            "required": true
+          },
+          "type": {
+            "annotation": "Literal['String', 'Number', 'Boolean', 'Date', 'List[String]', 'JSON']",
+            "default": "'String'",
+            "required": false
+          }
+        },
+        "kind": "pydantic_model",
+        "members": {},
+        "signature": "(*, prompt: str, type: Literal['String', 'Number', 'Boolean', 'Date', 'List[String]', 'JSON'] = 'String', format: str | None = None, enum: list[str] | None = None, examples: list[str] | None = None, bad_examples: list[str] | None = None, default: Any = None) -> None"
+      },
+      "FieldValidationError": {
+        "bases": [
+          "EnrichmentError",
+          "Exception",
+          "BaseException"
+        ],
+        "kind": "exception",
+        "members": {},
+        "signature": "(message: str, row_index: int | None = None, field: str | None = None)"
+      },
+      "FunctionStep": {
+        "kind": "class",
+        "members": {
+          "run": {
+            "kind": "method",
+            "signature": "(self, ctx: StepContext) -> StepResult"
+          }
+        },
+        "signature": "(name: str, fn: Callable[..., Any], fields: list[str], depends_on: list[str] | None = None, cache: bool = True, cache_version: str | None = None, run_if: Callable[..., Any] | None = None, skip_if: Callable[..., Any] | None = None)"
+      },
+      "GroundingConfig": {
+        "fields": {
+          "allowed_domains": {
+            "annotation": "list[str] | None",
+            "default": "None",
+            "required": false
+          },
+          "blocked_domains": {
+            "annotation": "list[str] | None",
+            "default": "None",
+            "required": false
+          },
+          "max_searches": {
+            "annotation": "int | None",
+            "default": "None",
+            "required": false
+          },
+          "provider_kwargs": {
+            "annotation": "dict[str, Any] | None",
+            "default": "None",
+            "required": false
+          },
+          "user_location": {
+            "annotation": "dict[str, str] | None",
+            "default": "None",
+            "required": false
+          }
+        },
+        "kind": "pydantic_model",
+        "members": {},
+        "signature": "(*, allowed_domains: list[str] | None = None, blocked_domains: list[str] | None = None, user_location: dict[str, str] | None = None, max_searches: int | None = None, provider_kwargs: dict[str, Any] | None = None) -> None"
+      },
+      "JsonlRunLogger": {
+        "kind": "class",
+        "members": {
+          "close": {
+            "kind": "method",
+            "signature": "(self) -> None"
+          }
+        },
+        "signature": "(path: str | Path, *, run_id: str | None = None, display_key: str | None = None, pipeline: Pipeline | None = None, data: pd.DataFrame | list[dict[str, Any]] | None = None, segment: str = 'run', t_offset: float = 0.0, retry_cells: dict[str, list[int]] | None = None, capture: str = 'metadata', config: EnrichmentConfig | None = None) -> None"
+      },
+      "LLMStep": {
+        "kind": "class",
+        "members": {
+          "build_messages": {
+            "kind": "method",
+            "signature": "(self, ctx: StepContext) -> tuple[list[dict[str, str]], dict[str, Any]]"
+          },
+          "is_batch_eligible": {
+            "kind": "property",
+            "signature": "(self) -> bool"
+          },
+          "parse_response": {
+            "kind": "method",
+            "signature": "(self, response: LLMResponse) -> StepResult"
+          },
+          "row_independent_system": {
+            "kind": "method",
+            "signature": "(self, row: dict[str, Any] | None = None, prior_results: dict[str, Any] | None = None) -> str"
+          },
+          "run": {
+            "kind": "method",
+            "signature": "(self, ctx: StepContext) -> StepResult"
+          }
+        },
+        "signature": "(name: str, fields: list[str] | dict[str, str | dict], depends_on: list[str] | None = None, model: str = 'gpt-4.1-mini', temperature: float | None = None, max_tokens: int | None = None, system_prompt: str | None = None, system_prompt_header: str | None = None, api_key: str | None = None, base_url: str | None = None, client: LLMClient | None = None, schema: Type[BaseModel] = <class 'EnrichmentResult'>, max_retries: int = 2, cache: bool = True, structured_outputs: bool | None = None, grounding: bool | dict | GroundingConfig | None = None, sources_field: str | None = 'sources', run_if: Callable[..., Any] | None = None, skip_if: Callable[..., Any] | None = None, batch: bool = False, provider_kwargs: dict[str, Any] | None = None)"
+      },
+      "Pipeline": {
+        "kind": "class",
+        "members": {
+          "clear_cache": {
+            "kind": "method",
+            "signature": "(self, step: str | None = None, cache_dir: str = '.accrue') -> int"
+          },
+          "execute": {
+            "kind": "method",
+            "signature": "(self, rows: list[dict[str, Any]], all_fields: dict[str, dict[str, Any]], config: EnrichmentConfig | None = None, prior_step_results: dict[str, list[dict[str, Any]]] | None = None, on_step_complete: Callable[[str, list[dict[str, Any]], list[RowError], set[int]], None] | None = None, cache_manager: Any = None, on_partial_checkpoint: Callable[[str, list[dict], int], None] | None = None, hooks: EnrichmentHooks | None = None, retry_cells: dict[str, list[int]] | None = None, capture: str = 'metadata') -> tuple[list[dict[str, Any]], list[RowError], CostSummary, dict[str, float]]"
+          },
+          "execution_levels": {
+            "kind": "property",
+            "signature": "(self) -> list[list[str]]"
+          },
+          "get_step": {
+            "kind": "method",
+            "signature": "(self, name: str) -> Step"
+          },
+          "plan": {
+            "kind": "method",
+            "signature": "(self, data: pd.DataFrame | list[dict[str, Any]], sample_size: int = 3, config: EnrichmentConfig | None = None) -> PipelinePlan"
+          },
+          "retry_failed": {
+            "kind": "method",
+            "signature": "(self, data: pd.DataFrame | list[dict[str, Any]], config: EnrichmentConfig | None = None, hooks: EnrichmentHooks | None = None, output_file: str | Path | None = None, *, rows: list[int] | None = None, steps: list[str] | None = None, run_log: bool | str | Path = False, display_key: str | None = None, data_identifier: str | None = None) -> PipelineResult"
+          },
+          "retry_failed_async": {
+            "kind": "method",
+            "signature": "(self, data: pd.DataFrame | list[dict[str, Any]], config: EnrichmentConfig | None = None, hooks: EnrichmentHooks | None = None, output_file: str | Path | None = None, *, rows: list[int] | None = None, steps: list[str] | None = None, run_log: bool | str | Path = False, display_key: str | None = None, data_identifier: str | None = None) -> PipelineResult"
+          },
+          "run": {
+            "kind": "method",
+            "signature": "(self, data: pd.DataFrame | list[dict[str, Any]], config: EnrichmentConfig | None = None, hooks: EnrichmentHooks | None = None, output_file: str | Path | None = None, confirm: bool = False, *, run_log: bool | str | Path = False, display_key: str | None = None, capture: str = 'metadata') -> PipelineResult"
+          },
+          "run_async": {
+            "kind": "method",
+            "signature": "(self, data: pd.DataFrame | list[dict[str, Any]], config: EnrichmentConfig | None = None, hooks: EnrichmentHooks | None = None, output_file: str | Path | None = None, *, run_log: bool | str | Path = False, display_key: str | None = None, capture: str = 'metadata') -> PipelineResult"
+          },
+          "runner": {
+            "kind": "method",
+            "signature": "(self, config: EnrichmentConfig | None = None) -> Any"
+          },
+          "step_names": {
+            "kind": "property",
+            "signature": "(self) -> list[str]"
+          }
+        },
+        "signature": "(steps: list[Step])"
+      },
+      "PipelineEndEvent": {
+        "kind": "dataclass",
+        "members": {},
+        "signature": "(num_rows: int, total_errors: int, cost: Any, elapsed_seconds: float) -> None"
+      },
+      "PipelineError": {
+        "bases": [
+          "EnrichmentError",
+          "Exception",
+          "BaseException"
+        ],
+        "kind": "exception",
+        "members": {},
+        "signature": "(message: str, row_index: int | None = None, field: str | None = None)"
+      },
+      "PipelinePlan": {
+        "kind": "dataclass",
+        "members": {
+          "summary": {
+            "kind": "method",
+            "signature": "(self) -> str"
+          }
+        },
+        "signature": "(steps: list[StepPlan], sample_rows: list[dict[str, Any]], sample_outputs: list[dict[str, Any]], sample_errors: list[RowError], total_rows: int, sample_size: int, sample_cost: CostSummary, estimated_cost: CostSummary) -> None"
+      },
+      "PipelineResult": {
+        "kind": "dataclass",
+        "members": {
+          "has_errors": {
+            "kind": "property",
+            "signature": "(self) -> bool"
+          },
+          "report": {
+            "kind": "method",
+            "signature": "(self, output_format: str = 'markdown', path: str | None = None, disable: list[str] | None = None) -> str"
+          },
+          "save": {
+            "kind": "method",
+            "signature": "(self, path: str | Path) -> Path"
+          },
+          "success_rate": {
+            "kind": "property",
+            "signature": "(self) -> float"
+          },
+          "summary": {
+            "kind": "method",
+            "signature": "(self) -> str"
+          }
+        },
+        "signature": "(data: pd.DataFrame | list[dict[str, Any]], cost: CostSummary = <factory>, errors: list[RowError] = <factory>, pipeline_elapsed_seconds: float = 0.0, step_elapsed_seconds: dict[str, float] = <factory>, field_specs: dict[str, dict[str, Any]] = <factory>) -> None"
+      },
+      "PipelineStartEvent": {
+        "kind": "dataclass",
+        "members": {},
+        "signature": "(step_names: list[str], num_rows: int, config: EnrichmentConfig) -> None"
+      },
+      "RowAttemptEvent": {
+        "kind": "dataclass",
+        "members": {},
+        "signature": "(step_name: str, row_index: int, attempt: int, kind: str, status: str, latency_ms: float | None, backoff_s: float | None, error: BaseException | None = None, body: dict[str, Any] | None = None) -> None"
+      },
+      "RowCompleteEvent": {
+        "kind": "dataclass",
+        "members": {},
+        "signature": "(step_name: str, row_index: int, values: dict[str, Any], error: BaseException | None, from_cache: bool, skipped: bool = False, usage: Any | None = None, elapsed_ms: float | None = None) -> None"
+      },
+      "RowError": {
+        "kind": "dataclass",
+        "members": {},
+        "signature": "(row_index: int, step_name: str, error: BaseException, error_type: str = '') -> None"
+      },
+      "Step": {
+        "kind": "protocol",
+        "members": {
+          "run": {
+            "kind": "method",
+            "signature": "(self, ctx: StepContext) -> StepResult"
+          }
+        }
+      },
+      "StepContext": {
+        "kind": "dataclass",
+        "members": {},
+        "signature": "(row: dict[str, Any], fields: dict[str, dict[str, Any]], prior_results: dict[str, Any], config: EnrichmentConfig | None = None, row_index: int | None = None, capture: str = 'metadata', on_attempt: Callable[[RowAttemptEvent], Awaitable[None]] | None = None) -> None"
+      },
+      "StepEndEvent": {
+        "kind": "dataclass",
+        "members": {},
+        "signature": "(step_name: str, num_rows: int, num_errors: int, usage: Any, elapsed_seconds: float, execution_mode: str = 'realtime', batch_id: str | None = None) -> None"
+      },
+      "StepError": {
+        "bases": [
+          "EnrichmentError",
+          "Exception",
+          "BaseException"
+        ],
+        "kind": "exception",
+        "members": {},
+        "signature": "(message: str, step_name: str | None = None, **kwargs: Any)"
+      },
+      "StepPlan": {
+        "kind": "dataclass",
+        "members": {},
+        "signature": "(name: str, kind: str, depends_on: list[str] = <factory>, model: str | None = None, system_prompt: str | None = None, response_format: dict[str, Any] | None = None) -> None"
+      },
+      "StepResult": {
+        "kind": "dataclass",
+        "members": {},
+        "signature": "(values: dict[str, Any], usage: Optional[UsageInfo] = None, metadata: dict[str, Any] = <factory>) -> None"
+      },
+      "StepStartEvent": {
+        "kind": "dataclass",
+        "members": {},
+        "signature": "(step_name: str, num_rows: int, level: int, execution_mode: str = 'realtime') -> None"
+      },
+      "compare": {
+        "kind": "function",
+        "signature": "(a: PipelineResult, b: PipelineResult, *, label_a: str = 'A', label_b: str = 'B') -> ComparisonResult"
+      },
+      "is_batch_capable": {
+        "kind": "function",
+        "signature": "(client: Any) -> bool"
+      },
+      "read_prompt_ref": {
+        "kind": "function",
+        "signature": "(sidecar_path: str | Path, off: int, len: int) -> dict[str, Any]"
+      },
+      "setup_logging": {
+        "kind": "function",
+        "signature": "(level: str = 'INFO', format_type: \"Literal['console', 'json']\" = 'console', include_timestamp: bool = True) -> None"
+      },
+      "web_search": {
+        "kind": "function",
+        "signature": "(query: str, *, model: str = 'gpt-4.1-mini', search_context_size: str = 'medium', api_key: str | None = None, include_sources: bool = True, user_location: dict[str, str] | None = None, allowed_domains: list[str] | None = None, tool_type: str = 'web_search') -> Callable[[StepContext], Awaitable[dict[str, Any]]]"
+      }
+    }
+  },
+  "accrue.core.exceptions": {
+    "exports": [
+      "ConfigurationError",
+      "EnrichmentError",
+      "FieldValidationError",
+      "PipelineError",
+      "RowError",
+      "StepError"
+    ],
+    "names": {
+      "ConfigurationError": {
+        "bases": [
+          "EnrichmentError",
+          "Exception",
+          "BaseException"
+        ],
+        "kind": "exception",
+        "members": {},
+        "signature": "(message: str, row_index: int | None = None, field: str | None = None)"
+      },
+      "EnrichmentError": {
+        "bases": [
+          "Exception",
+          "BaseException"
+        ],
+        "kind": "exception",
+        "members": {},
+        "signature": "(message: str, row_index: int | None = None, field: str | None = None)"
+      },
+      "FieldValidationError": {
+        "bases": [
+          "EnrichmentError",
+          "Exception",
+          "BaseException"
+        ],
+        "kind": "exception",
+        "members": {},
+        "signature": "(message: str, row_index: int | None = None, field: str | None = None)"
+      },
+      "PipelineError": {
+        "bases": [
+          "EnrichmentError",
+          "Exception",
+          "BaseException"
+        ],
+        "kind": "exception",
+        "members": {},
+        "signature": "(message: str, row_index: int | None = None, field: str | None = None)"
+      },
+      "RowError": {
+        "kind": "dataclass",
+        "members": {},
+        "signature": "(row_index: int, step_name: str, error: BaseException, error_type: str = '') -> None"
+      },
+      "StepError": {
+        "bases": [
+          "EnrichmentError",
+          "Exception",
+          "BaseException"
+        ],
+        "kind": "exception",
+        "members": {},
+        "signature": "(message: str, step_name: str | None = None, **kwargs: Any)"
+      }
+    }
+  },
+  "accrue.data": {
+    "exports": [
+      "FieldManager",
+      "load_fields"
+    ],
+    "names": {
+      "FieldManager": {
+        "kind": "class",
+        "members": {
+          "from_csv": {
+            "kind": "classmethod",
+            "signature": "(cls, csv_path: str) -> FieldManager"
+          },
+          "get_categories": {
+            "kind": "method",
+            "signature": "(self) -> list[str]"
+          },
+          "get_category_fields": {
+            "kind": "method",
+            "signature": "(self, category: str) -> dict[str, dict[str, Any]]"
+          },
+          "get_field_count": {
+            "kind": "method",
+            "signature": "(self, category: str | None = None) -> int"
+          },
+          "validate_category": {
+            "kind": "method",
+            "signature": "(self, category: str) -> bool"
+          }
+        },
+        "signature": "(fields_categories_path: str) -> None"
+      },
+      "load_fields": {
+        "kind": "function",
+        "signature": "(csv_path: str, category: str | None = None) -> dict[str, dict[str, Any]]"
+      }
+    }
+  },
+  "accrue.providers": {
+    "exports": [
+      "AnthropicClient",
+      "GoogleClient",
+      "LLMAPIError",
+      "LLMClient",
+      "LLMResponse",
+      "OpenAIClient"
+    ],
+    "names": {
+      "AnthropicClient": {
+        "kind": "class",
+        "members": {
+          "cancel_batch": {
+            "kind": "method",
+            "signature": "(self, batch_id: str) -> None"
+          },
+          "complete": {
+            "kind": "method",
+            "signature": "(self, messages: list[dict[str, Any]], model: str, temperature: float | None, max_tokens: int, response_format: dict[str, Any] | None = None, tools: list[dict[str, Any]] | None = None, provider_kwargs: dict[str, Any] | None = None) -> LLMResponse"
+          },
+          "poll_batch": {
+            "kind": "method",
+            "signature": "(self, batch_id: str, poll_interval: float = 60.0, timeout: float = 86400.0) -> BatchResult"
+          },
+          "submit_batch": {
+            "kind": "method",
+            "signature": "(self, requests: list[BatchRequest], metadata: dict[str, str] | None = None) -> str"
+          }
+        },
+        "signature": "(api_key: str | None = None, http_client: Any | None = None)"
+      },
+      "GoogleClient": {
+        "kind": "class",
+        "members": {
+          "complete": {
+            "kind": "method",
+            "signature": "(self, messages: list[dict[str, Any]], model: str, temperature: float, max_tokens: int, response_format: dict[str, Any] | None = None, tools: list[dict[str, Any]] | None = None, provider_kwargs: dict[str, Any] | None = None) -> LLMResponse"
+          }
+        },
+        "signature": "(api_key: str | None = None, http_client: Any | None = None)"
+      },
+      "LLMAPIError": {
+        "bases": [
+          "Exception",
+          "BaseException"
+        ],
+        "kind": "exception",
+        "members": {
+          "retryable": {
+            "kind": "property",
+            "signature": "(self) -> bool"
+          }
+        },
+        "signature": "(message: str, *, status_code: int | None = None, retry_after: float | None = None, is_rate_limit: bool = False, retryable: bool | None = None)"
+      },
+      "LLMClient": {
+        "kind": "protocol",
+        "members": {
+          "complete": {
+            "kind": "method",
+            "signature": "(self, messages: list[dict[str, Any]], model: str, temperature: float, max_tokens: int, response_format: dict[str, Any] | None = None, tools: list[dict[str, Any]] | None = None, provider_kwargs: dict[str, Any] | None = None) -> LLMResponse"
+          }
+        }
+      },
+      "LLMResponse": {
+        "kind": "dataclass",
+        "members": {},
+        "signature": "(content: str, usage: UsageInfo | None = None, citations: list[Citation] = <factory>) -> None"
+      },
+      "OpenAIClient": {
+        "kind": "class",
+        "members": {
+          "cancel_batch": {
+            "kind": "method",
+            "signature": "(self, batch_id: str) -> None"
+          },
+          "complete": {
+            "kind": "method",
+            "signature": "(self, messages: list[dict[str, Any]], model: str, temperature: float, max_tokens: int, response_format: dict[str, Any] | None = None, tools: list[dict[str, Any]] | None = None, provider_kwargs: dict[str, Any] | None = None) -> LLMResponse"
+          },
+          "poll_batch": {
+            "kind": "method",
+            "signature": "(self, batch_id: str, poll_interval: float = 60.0, timeout: float = 86400.0) -> BatchResult"
+          },
+          "submit_batch": {
+            "kind": "method",
+            "signature": "(self, requests: list[BatchRequest], metadata: dict[str, str] | None = None) -> str"
+          },
+          "supports_batch": {
+            "kind": "property",
+            "signature": "(self) -> bool"
+          }
+        },
+        "signature": "(api_key: str | None = None, base_url: str | None = None, http_client: Any | None = None)"
+      }
+    }
+  }
+}

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,320 @@
+"""A CI contract on the public API surface.
+
+Accrue ships to PyPI with downstream users, and an increasing share of pull
+requests are authored by agents. Nothing else in CI notices when the exported
+surface changes: a renamed keyword argument, a dropped export, or a reordered
+positional parameter sails through ``ruff`` and ``pytest`` as long as the
+(mostly mocked) unit tests still pass. This module rebuilds the surface at test
+time and diffs it against a committed snapshot, so changing the public API
+becomes an *intentional* act with a reviewable diff.
+
+The point is not to block change. It is to force every surface change into the
+pull request as readable JSON, where ``- "signature": ...`` sits next to the
+``+`` line and a reviewer can see what a caller would have to rewrite.
+
+Scope is the four modules users are actually told to import from — see
+``MODULES``. ``docs/`` and ``examples/`` import ``AnthropicClient``,
+``load_fields`` and ``ConfigurationError`` directly, so a snapshot limited to
+``accrue.__all__`` would leave documented names ungated.
+
+Regenerate after an intentional change::
+
+    python -m tests.test_public_api --update
+
+Design notes, because the naive implementations are all subtly wrong:
+
+* Members are filtered to those *defined in accrue*. ``inspect.getmembers`` on
+  a Pydantic model reports 28 inherited names (``model_dump``,
+  ``model_validate``, ...) and none of accrue's own, so an unfiltered snapshot
+  would record Pydantic's API and turn every Pydantic release into a CI
+  failure.
+* Pydantic models are captured by ``model_fields``, not by methods — the fields
+  *are* the API.
+* Protocols are captured by their methods. ``Step`` and
+  ``BatchCapableLLMClient`` both render as ``(*args, **kwargs)`` at class
+  level, which says nothing about what an implementer must provide.
+* Defaults come from ``inspect.signature``, whose ``<factory>`` sentinel is
+  stable, and never from ``dataclasses.fields()``, whose raw defaults render as
+  ``<_MISSING_TYPE object at 0x7f...>`` and would differ between runs.
+
+The rendered surface is byte-identical on Python 3.10 through 3.13 and across
+Pydantic 2.0 through 2.13, which is why this test runs on the whole CI matrix
+rather than being pinned to one interpreter.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import importlib
+import inspect
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+try:  # pydantic is a base dependency; guard only so a partial env fails clearly
+    import pydantic
+except ImportError:  # pragma: no cover - base dependency, present in every env
+    pydantic = None  # type: ignore[assignment]
+
+SNAPSHOT_PATH = Path(__file__).with_name("public_api_snapshot.json")
+
+REGEN_HINT = (
+    "If this change was intentional:\n"
+    "  1. Regenerate the snapshot:  python -m tests.test_public_api --update\n"
+    "  2. Commit the updated tests/public_api_snapshot.json in this same PR\n"
+    "  3. Add a CHANGELOG.md entry under [Unreleased] describing the change\n"
+    "If it was not intentional, you have changed accrue's public API by "
+    "accident — restore the old names and signatures instead."
+)
+
+#: Modules whose public surface is under contract. ``exports_from_all`` is
+#: False for modules that define no ``__all__``; those fall back to the public
+#: names *defined in that module*, which keeps re-imported helpers such as
+#: ``typing.Any`` out of the snapshot.
+MODULES: tuple[tuple[str, bool], ...] = (
+    ("accrue", True),
+    ("accrue.providers", True),
+    ("accrue.data", True),
+    ("accrue.core.exceptions", False),
+)
+
+
+def _render(text: str | None) -> str | None:
+    """Normalise a rendered signature so diffs stay legible.
+
+    Modules using ``from __future__ import annotations`` render annotations as
+    quoted source text (``name: 'str'``) while Pydantic models render evaluated
+    objects (``name: str``). Both forms are stable, but mixing them in one file
+    makes the snapshot harder to read than it needs to be.
+    """
+    if text is None:
+        return None
+    text = re.sub(r": '([^']+)'", r": \1", text)
+    text = re.sub(r"-> '([^']+)'", r"-> \1", text)
+    text = text.replace("typing.", "")
+    text = re.sub(r"\baccrue(?:\.\w+)+\.(\w+)", r"\1", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _signature(obj: Any) -> str | None:
+    try:
+        return _render(str(inspect.signature(obj)))
+    except (TypeError, ValueError):
+        return None
+
+
+def _kind(obj: Any) -> str:
+    if inspect.isclass(obj):
+        if getattr(obj, "_is_protocol", False):
+            return "protocol"
+        if issubclass(obj, BaseException):
+            return "exception"
+        if pydantic is not None and issubclass(obj, pydantic.BaseModel):
+            return "pydantic_model"
+        if dataclasses.is_dataclass(obj):
+            return "dataclass"
+        return "class"
+    if inspect.isfunction(obj) or inspect.isbuiltin(obj):
+        return "function"
+    return type(obj).__name__
+
+
+def _members(cls: type) -> dict[str, dict[str, Any]]:
+    """Public methods, properties and attributes *defined in accrue*.
+
+    Uses ``getattr_static`` so descriptors are inspected rather than invoked,
+    and filters on ``__module__`` so inherited third-party API (Pydantic's, in
+    particular) never enters the snapshot. Methods inherited from another
+    accrue class are kept — they are part of this class's surface.
+    """
+    out: dict[str, dict[str, Any]] = {}
+    for name in sorted(dir(cls)):
+        if name.startswith("_"):
+            continue
+        try:
+            value = inspect.getattr_static(cls, name)
+        except AttributeError:  # pragma: no cover - defensive
+            continue
+
+        if isinstance(value, property):
+            func = value.fget
+            module = getattr(func, "__module__", None)
+            entry = {"kind": "property", "signature": _signature(func) if func else None}
+        elif isinstance(value, (staticmethod, classmethod)):
+            module = getattr(value.__func__, "__module__", None)
+            entry = {"kind": type(value).__name__, "signature": _signature(value.__func__)}
+        elif callable(value):
+            module = getattr(value, "__module__", None)
+            entry = {"kind": "method", "signature": _signature(value)}
+        else:
+            module = getattr(type(value), "__module__", None)
+            entry = {"kind": "attribute"}
+
+        if module and module.split(".")[0] == "accrue":
+            out[name] = entry
+    return out
+
+
+def _describe(obj: Any) -> dict[str, Any]:
+    kind = _kind(obj)
+    entry: dict[str, Any] = {"kind": kind}
+
+    # A Protocol's own signature is a meaningless ``(*args, **kwargs)``.
+    if kind != "protocol":
+        entry["signature"] = _signature(obj)
+
+    if inspect.isclass(obj):
+        entry["members"] = _members(obj)
+        if kind == "exception":
+            entry["bases"] = [b.__name__ for b in obj.__mro__[1:] if b is not object]
+        if kind == "pydantic_model":
+            entry["fields"] = {
+                name: {
+                    "annotation": _render(str(field.annotation)),
+                    "required": field.is_required(),
+                    "default": None if field.is_required() else repr(field.default),
+                }
+                for name, field in sorted(obj.model_fields.items())
+            }
+    return entry
+
+
+def _public_names(module: Any, from_all: bool) -> list[str]:
+    if from_all:
+        return sorted(module.__all__)
+    return sorted(
+        name
+        for name, value in vars(module).items()
+        if not name.startswith("_") and getattr(value, "__module__", None) == module.__name__
+    )
+
+
+def build_surface() -> dict[str, Any]:
+    """Rebuild the public API surface from the live package."""
+    surface: dict[str, Any] = {}
+    for module_name, from_all in MODULES:
+        module = importlib.import_module(module_name)
+        names = _public_names(module, from_all)
+        entries: dict[str, Any] = {}
+        for name in names:
+            # A name in __all__ that is not actually importable is itself a
+            # defect — `from accrue import *` would raise for downstream users.
+            assert hasattr(module, name), (
+                f"{module_name}.__all__ lists {name!r} but the module has no such "
+                f"attribute. `from {module_name} import *` would fail for users."
+            )
+            entries[name] = _describe(getattr(module, name))
+        surface[module_name] = {"exports": names, "names": entries}
+    return surface
+
+
+def _flatten(value: Any, prefix: str = "") -> dict[str, Any]:
+    """Flatten nested dicts to dotted paths so diffs can point at one field."""
+    if isinstance(value, dict):
+        flat: dict[str, Any] = {}
+        for key, item in value.items():
+            flat.update(_flatten(item, f"{prefix}.{key}" if prefix else str(key)))
+        return flat
+    return {prefix: value}
+
+
+def _describe_change(path: str, old: Any, new: Any) -> str:
+    """Render one changed value.
+
+    Lists (the per-module ``exports``) are rendered as element deltas. Printing
+    two 33-name lists in full and leaving the reader to spot the difference is
+    exactly the kind of unreadable failure this test exists to avoid.
+    """
+    if isinstance(old, list) and isinstance(new, list):
+        gone = sorted(set(old) - set(new))
+        came = sorted(set(new) - set(old))
+        parts = [f"    ~ {path}:"]
+        if gone:
+            parts.append(f"        no longer exported: {', '.join(gone)}")
+        if came:
+            parts.append(f"        newly exported:     {', '.join(came)}")
+        if not gone and not came:  # same members, different order
+            parts.append(f"        reordered: {new!r}")
+        return "\n".join(parts)
+    return f"    ~ {path}:\n        was: {old!r}\n        now: {new!r}"
+
+
+def _format_delta(expected: dict[str, Any], actual: dict[str, Any]) -> str:
+    old, new = _flatten(expected), _flatten(actual)
+    removed = sorted(set(old) - set(new))
+    added = sorted(set(new) - set(old))
+    changed = sorted(k for k in set(old) & set(new) if old[k] != new[k])
+
+    lines: list[str] = ["accrue's public API no longer matches the committed snapshot.", ""]
+    if removed:
+        lines.append(f"REMOVED ({len(removed)}) — breaking for downstream users:")
+        lines += [f"    - {k}: {old[k]!r}" for k in removed]
+        lines.append("")
+    if changed:
+        lines.append(f"CHANGED ({len(changed)}) — check whether existing callers still work:")
+        lines += [_describe_change(k, old[k], new[k]) for k in changed]
+        lines.append("")
+    if added:
+        lines.append(f"ADDED ({len(added)}) — additive, but still a public API change:")
+        lines += [f"    + {k}: {new[k]!r}" for k in added]
+        lines.append("")
+    lines.append(REGEN_HINT)
+    return "\n".join(lines)
+
+
+def write_snapshot() -> Path:
+    """Write the current surface to the snapshot file. Used by ``--update``."""
+    payload = json.dumps(build_surface(), indent=2, sort_keys=True)
+    SNAPSHOT_PATH.write_text(payload + "\n", encoding="utf-8")
+    return SNAPSHOT_PATH
+
+
+@pytest.mark.skipif(not SNAPSHOT_PATH.exists(), reason="not running from a source checkout")
+def test_public_api_matches_snapshot() -> None:
+    """The exported surface must match the committed snapshot exactly.
+
+    Additions fail too, deliberately. A subset check would let new exports land
+    unreviewed and leave the snapshot permanently stale, so it would stop being
+    a truthful answer to "what is accrue's public API?".
+    """
+    expected = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+    actual = build_surface()
+    if actual != expected:
+        # pytest.fail rather than a bare assert: pytest's own introspection
+        # would append a truncated dict-vs-dict dump underneath the curated
+        # delta, which is precisely the unreadable output this replaces.
+        pytest.fail(_format_delta(expected, actual), pytrace=False)
+
+
+def test_snapshot_is_canonically_formatted() -> None:
+    """The committed file must be exactly what ``--update`` writes.
+
+    Otherwise a hand-edited snapshot could pass the diff above while producing
+    a spurious whole-file diff the next time someone regenerates it.
+    """
+    on_disk = SNAPSHOT_PATH.read_text(encoding="utf-8")
+    canonical = json.dumps(json.loads(on_disk), indent=2, sort_keys=True) + "\n"
+    assert on_disk == canonical, (
+        "tests/public_api_snapshot.json is not in canonical form. Do not edit it "
+        "by hand — regenerate it:\n"
+        "  python -m tests.test_public_api --update"
+    )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="rewrite tests/public_api_snapshot.json from the live package",
+    )
+    args = parser.parse_args()
+    if not args.update:
+        parser.error("nothing to do — pass --update to regenerate the snapshot")
+    path = write_snapshot()
+    print(f"Wrote {path}")
+    print("Review the diff, then commit it with a CHANGELOG.md entry under [Unreleased].")


### PR DESCRIPTION
Closes #121.

## Why

Nothing in CI noticed when accrue's exported surface changed. A renamed kwarg, a dropped export, or a reordered positional parameter sailed through `ruff` and `pytest` as long as the (mostly mocked) tests still passed. With a growing share of PRs authored by agents, that gap is worth closing.

The point isn't to block change — it's to force every surface change into the PR diff as readable JSON, where `- "signature": ...` sits next to the `+` line and a reviewer can see what a caller would have to rewrite.

## What

- **`tests/public_api_snapshot.json`** — 47 names across four modules: kind, signature, accrue-defined members, Pydantic model fields, Protocol methods, exception base chains.
- **`tests/test_public_api.py`** — rebuilds the surface at test time and fails on divergence, plus a second test asserting the file is canonically formatted so a hand-edited snapshot can't pass and then churn on the next regen.
- **`CLAUDE.md` / `CHANGELOG.md`** — regen entry point and an `[Unreleased]` entry.

## Decisions worth reviewing

**Scope reaches past `accrue.__all__`.** `docs/` and `examples/` import `AnthropicClient`, `GoogleClient`, `load_fields` and `ConfigurationError` directly, so a snapshot of `__all__` alone would leave documented names ungated — an agent could rename `load_fields`, keep CI green, and break the docs. `accrue.providers` and `accrue.data` already define their own `__all__`; `accrue.core.exceptions` doesn't, so it falls back to names *defined in that module* (which correctly excludes the re-imported `typing.Any`).

**Additions fail too.** A subset check would let new exports land unreviewed and leave the snapshot permanently stale, so it would stop being a truthful answer to "what is accrue's public API?". Based on the last 12 months, this fires on roughly 1 PR in 7.

**Paths differ from the issue text.** The issue names `tests/unit/`; this repo has a flat `tests/`, so the files follow `test_repo_metadata.py` as precedent.

## Implementation notes

The naive versions are all subtly wrong, so:

- **Members are filtered to those defined in accrue.** Unfiltered, `FieldSpec`/`GroundingConfig`/`CostSummary` each contribute 28 inherited Pydantic names (`model_dump`, `model_validate`, …) and *zero* of their own — every Pydantic release would turn CI red while gating nothing.
- **Pydantic models are captured by `model_fields`**, not methods. The fields are the API.
- **Protocols are captured by their methods.** `Step` and `BatchCapableLLMClient` both render as `(*args, **kwargs)` at class level, which says nothing about what an implementer must provide.
- **Defaults come from `inspect.signature`** (whose `<factory>` sentinel is stable) and never from `dataclasses.fields()`, whose raw defaults render as `<_MISSING_TYPE object at 0x7f...>` and would differ between runs.
- `pytest.fail(..., pytrace=False)` rather than a bare `assert`, so pytest's truncated dict-vs-dict dump doesn't get appended underneath the curated delta.

## Verification

- Full suite: **807 passed, 1 skipped** (806 → 808 total).
- `ruff check` + `ruff format --check` clean.
- Snapshot is **byte-identical on Python 3.10 / 3.11 / 3.12 / 3.13** and across **Pydantic 2.0.3 → 2.13.4**, so the test runs on the whole matrix unpinned rather than being tied to one interpreter. This was the main risk: CI resolves deps unbounded, and `test.yml` records main sitting red for six weeks after ruff 0.16 and openai 3.0.
- Gate mutation-tested three ways — removed export, renamed kwarg, added export — confirming each produces a correct, readable failure. Example:

```
accrue's public API no longer matches the committed snapshot.

CHANGED (1) — check whether existing callers still work:
    ~ accrue.names.web_search.signature:
        was: "(query: str, *, model: str = 'gpt-4.1-mini', search_context_size: str = 'medium', ...)"
        now: "(query: str, *, model: str = 'gpt-4.1-mini', context_size: str = 'medium', ...)"

If this change was intentional:
  1. Regenerate the snapshot:  python -m tests.test_public_api --update
  2. Commit the updated tests/public_api_snapshot.json in this same PR
  3. Add a CHANGELOG.md entry under [Unreleased] describing the change
```

No new dependencies — stdlib `inspect` only.

## Follow-up

The issue's Notes suggest a companion test pinning `[project.dependencies]` to make the "never litellm" rule executable. Deferred to its own PR, as the issue allows.