### PR TITLE
docs: sync CLAUDE.md with the 1.4.0 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Accrue
 
-Composable enrichment pipeline engine. The gap between Instructor (single LLM call) and Clay (full SaaS platform). v1.3.0, Python 3.10+.
+Composable enrichment pipeline engine. The gap between Instructor (single LLM call) and Clay (full SaaS platform). v1.4.0, Python 3.10+.
 
 ## Commands
 
@@ -80,7 +80,7 @@ See `docs/guides/` for details.
 |-------|--------|
 | 1-5 (Core engine through DX) | COMPLETE |
 | 6A Ship: examples, README, PyPI | COMPLETE |
-| 6B Power user: conditional steps, grounding (done); batch API (#62, OpenAI+Anthropic); waterfall, chunked, CLI (remaining) | IN PROGRESS |
+| 6B Power user: conditional steps, grounding, batch API (#62, OpenAI+Anthropic), run log + `accrue watch` CLI (done); waterfall, chunked (remaining) | IN PROGRESS |
 
 ## Keeping Docs in Sync
 


### PR DESCRIPTION
Two lines in `CLAUDE.md` went stale the moment 1.4.0 shipped.

- **Line 3** still described the project as `v1.3.0`. 1.4.0 is now published to PyPI.
- **The 6B phase row** listed `CLI` as remaining work. The `accrue` console script and its `watch` subcommand shipped in 1.4.0 alongside the run log — `waterfall` and `chunked` are what actually remain.

`CLAUDE.md` is loaded at the start of every agent session, so both would have been read as current fact by anything working in this repo.