### PR TITLE
docs: codify scope guardrails in CLAUDE.md (#122)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,17 @@ Accrue is built using an agentic software development lifecycle modelled on Anth
 
 The patterns here are taken from the official documentation, not guessed. Citations are at the bottom of this file.
 
+> **Before proposing or building a feature, read the [Scope](CLAUDE.md#scope) section of CLAUDE.md.**
+> It states what accrue deliberately will not ship. Out-of-scope proposals get labelled
+> `wontfix` or `backlog` with a one-line rationale — they don't get built.
+
 ## TL;DR
 
 | What | Trigger | Where |
 |---|---|---|
 | `@claude` mention bot | Comment containing `@claude` on any issue, PR, or review | `.github/workflows/claude.yml` |
-| Auto PR review (inline) | Every non-draft PR opened/updated against `main` | `.github/workflows/claude-review.yml` |
-| Weekly maintenance | Sunday 02:00 UTC + manual `workflow_dispatch` | `.github/workflows/weekly-maintenance.yml` |
+| PR review | Ad hoc — comment `@claude review`, or review locally | `.github/workflows/claude.yml` |
+| Repo maintenance | Monthly (1st, 06:00 UTC) + manual `workflow_dispatch` | `.github/workflows/maintenance.yml` |
 | Accrue-triages-accrue | New issue opened | `.github/workflows/accrue-triage.yml` |
 | Lint-on-edit (local) | After every Edit/Write tool call by Claude Code | `.claude/settings.json` + `.claude/hooks/lint-changed.sh` |
 | `/ship-issue <num>` | Local Claude Code | `.claude/skills/ship-issue/SKILL.md` |
@@ -48,8 +52,8 @@ When working in this repo with Claude Code, four project-scoped commands appear 
 ### 2. CI — agents on GitHub
 
 - **`@claude` mention bot.** Comment `@claude implement #9` on any issue or PR and the action picks it up. v1 auto-detects mode from event context — no `mode:` input needed.
-- **Auto PR review.** Runs on every non-draft PR. Uses `track_progress: true` for a visible tracking comment, and the `mcp__github_inline_comment__create_inline_comment` MCP tool so feedback lands as inline review comments rather than one wall of text. Tools are scoped via `claude_args: --allowedTools` for safety.
-- **Weekly maintenance.** Cron + `workflow_dispatch`. Sweeps stale issues, doc drift, version coherence, examples sanity. Posts one summary issue per run.
+- **PR review — ad hoc, not automatic.** The auto-review job was dropped in #136; nothing reviews PRs on its own. Review the diff locally with Claude Code, or comment `@claude review` on the PR (that path is `claude.yml`, which fires on `issue_comment` in base-repo context and so has repository secrets even for fork PRs). Green CI is not a review — see the merge rules in CLAUDE.md.
+- **Repo maintenance.** Monthly cron + `workflow_dispatch`. Sweeps stale issues, doc drift, and stuck PRs/red CI. It posts *only* when it finds something, and edits one rolling issue rather than opening a new one per run — the previous version's "post even when clean" instruction made it the largest single contributor to the open-issue queue. Version coherence and examples sanity moved to `tests/test_repo_metadata.py`, which runs on every commit and cannot hallucinate.
 
 ### 3. Dogfooded triage — the meta move
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,37 @@
 
 Composable enrichment pipeline engine. The gap between Instructor (single LLM call) and Clay (full SaaS platform). v1.4.0, Python 3.10+.
 
+## Scope
+
+Accrue is a composable pipeline **engine**, not a platform. The positioning — the gap
+between Instructor (single LLM call) and Clay (full SaaS platform) — is a constraint,
+not a slogan. Check a proposal against it before writing code.
+
+**IN**
+
+- New step types, provider adapters, field-spec features
+- Caching, batching, cost accounting, retries, checkpointing
+- Anything making a pipeline cheaper, more reliable, or easier to reason about
+- Run observability *as data* — the run-log contract is accrue's half of that
+
+**OUT**
+
+- **Bundled third-party integrations** (Sheets, Airtable, Salesforce, CRM connectors).
+  `pipeline.serve()` (#34) is the story for connecting accrue to live systems: it makes
+  a pipeline callable by anything speaking HTTP/MCP without accrue owning one connector.
+- **Hosted anything** — no accounts, no server we run, no scheduler.
+- **The dashboard.** Accrue Watch lives in
+  [accrue-ui](https://github.com/matt-house-e/accrue-ui); core ships the run log and the
+  `accrue watch` handoff, nothing more.
+- **Orchestrator ambitions.** Dagster/Prefect/Airflow call accrue, not the reverse.
+
+**Why minimal deps.** Users embed accrue in their own stacks, so every dependency is
+theirs too — a version conflict we import is one they have to solve. Base deps are
+`openai`, `pydantic`, `pandas`, `tqdm`, `python-dotenv`; provider SDKs are extras.
+
+**Out-of-scope proposals** get labelled `wontfix` or `backlog` with a one-line rationale.
+Don't build them, and don't leave them open to dilute the roadmap.
+
 ## Commands
 
 ```bash
@@ -21,7 +52,7 @@ pip install -e ".[google]"      # With Google provider
 - **Step data**: `dict[str, Any]` not `pd.Series`. Steps are pure, no pandas inside.
 - **Internal fields**: `__` prefix (e.g. `__web_context`) for inter-step data, filtered from output.
 - **Prompt split**: `build_prompt()` returns `PromptParts(system, user)`. Keep the `system` half row-independent — providers cache on an exact prefix match, so any per-row content in it turns caching into a 1.25x surcharge (#107).
-- **Minimal deps**: Base: `openai`, `pydantic`, `pandas`, `tqdm`, `python-dotenv`. Never add litellm/langfuse.
+- **Minimal deps**: Base: `openai`, `pydantic`, `pandas`, `tqdm`, `python-dotenv`. Never add litellm/langfuse — see [Scope](#scope) for why.
 - **Public API is under contract.** `tests/public_api_snapshot.json` pins every name exported from `accrue`, `accrue.providers`, `accrue.data` and `accrue.core.exceptions`. Any change to that surface — including a purely additive one — fails `tests/test_public_api.py`. That is deliberate: it puts the change in the PR diff as readable JSON. To change the API on purpose, run `python -m tests.test_public_api --update`, commit the regenerated snapshot in the same PR, and add a `CHANGELOG.md` entry under `[Unreleased]`. Never hand-edit the snapshot (#121).
 - See `docs/guides/` for architecture, providers, caching, grounding, run-log details.
 - **Run-log contract v1**: `run(..., run_log=True)` emits JSONL via `JsonlRunLogger` (a hooks consumer, `accrue/core/runlog.py`). Additive changes only within v1 — never rename/remove fields without bumping `SCHEMA_VERSION`; golden fixture `tests/fixtures/run_small.jsonl` is what accrue-ui tests against. `pipeline_start` carries a nested `manifest` object (the run's definition: steps+types+models, field schema, config — built by `accrue/core/manifest.py`, #138) that must stay row-independent and deterministic (no timestamps/rng); regenerate the fixture with `python tests/fixtures/generate_run_fixture.py` and keep `test_regeneration_is_stable` green.


### PR DESCRIPTION
Closes #122.

## Scope section

CLAUDE.md gains a `Scope` section, placed directly under the positioning line it expands. It gives an agent something to check a proposal *against* before writing code:

- **IN** — new step types, provider adapters, field specs, caching/batching/cost/retries, run observability as data.
- **OUT** — bundled connectors (with `pipeline.serve()` #34 named as the alternative story), hosted anything, the dashboard (accrue-ui owns it; core ships the run log and the `accrue watch` handoff), and orchestrator ambitions.
- **Why minimal deps** — stated with the reason, not just the rule: users embed accrue in their own stacks, so a version conflict we import is one they have to solve.
- **Disposition** — out-of-scope proposals get `wontfix` or `backlog` plus a one-line rationale, rather than being built or left open to dilute the roadmap.

The existing `Minimal deps` bullet under Code Style now points here for the rationale instead of restating it.

## AGENTS.md

Cross-references the Scope section up front, so the mention bot and the maintenance job inherit it — `claude.yml` picks up CLAUDE.md and AGENTS.md automatically in the runner.

## Unplanned: three false statements in AGENTS.md

Found while adding that cross-reference. All three would be read literally by an agent:

1. The TL;DR table and a CI bullet both described an **"Auto PR review (inline)" running on every non-draft PR via `claude-review.yml`**. That workflow was deleted in #136 — nothing reviews PRs automatically. An agent reading this would assume review coverage that does not exist, which is precisely what #124 added merge rules to prevent. Replaced with the ad-hoc reality (`@claude review`, or review locally).
2. **"Weekly maintenance … `weekly-maintenance.yml`"** — the file is `maintenance.yml` and the cron is `0 6 1 * *`, i.e. monthly.
3. The maintenance bullet claimed it **"posts one summary issue per run"** and sweeps version coherence and examples sanity. It now posts only on findings and edits one rolling issue; the other two checks moved to `tests/test_repo_metadata.py`. The old behaviour is what made that job the largest contributor to the open-issue queue.

Docs-only. `ruff` clean, 977 passed / 1 skipped locally.